### PR TITLE
Global gpgcheck flags

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -101,6 +101,7 @@ class Answerfile:
             else:
                 raise AnswerfileException("Unknown mode, %s" % install_type)
 
+            results['gpgcheck'] = getBoolAttribute(self.top_node, ['gpgcheck'], default = True)
             results['repo-gpgcheck'] = getBoolAttribute(self.top_node, ['repo-gpgcheck'], default = True)
             results.update(self.parseCommon())
         elif self.operation == 'restore':

--- a/answerfile.py
+++ b/answerfile.py
@@ -101,6 +101,7 @@ class Answerfile:
             else:
                 raise AnswerfileException("Unknown mode, %s" % install_type)
 
+            results['repo-gpgcheck'] = getBoolAttribute(self.top_node, ['repo-gpgcheck'], default = True)
             results.update(self.parseCommon())
         elif self.operation == 'restore':
             results = self.parseRestore()

--- a/backend.py
+++ b/backend.py
@@ -426,6 +426,9 @@ def performInstallation(answers, ui_package, interactive):
     if not main_repositories or main_repositories[0].identifier() != MAIN_REPOSITORY_NAME:
         raise RuntimeError("No main repository found")
 
+    if 'gpgcheck' in answers and not answers['gpgcheck']:
+        for repo in main_repositories: # update_repositories currently do not check anyway
+            repo.disableGpgCheck()
     if 'repo-gpgcheck' in answers and not answers['repo-gpgcheck']:
         for repo in main_repositories: # update_repositories currently do not check anyway
             repo.disableRepoGpgCheck()

--- a/backend.py
+++ b/backend.py
@@ -426,6 +426,10 @@ def performInstallation(answers, ui_package, interactive):
     if not main_repositories or main_repositories[0].identifier() != MAIN_REPOSITORY_NAME:
         raise RuntimeError("No main repository found")
 
+    if 'repo-gpgcheck' in answers and not answers['repo-gpgcheck']:
+        for repo in main_repositories: # update_repositories currently do not check anyway
+            repo.disableRepoGpgCheck()
+
     handleMainRepos(main_repositories, answers)
     if update_repositories:
         handleRepos(update_repositories, answers)

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -46,6 +46,15 @@ Common Attributes
     Validity: any <installation> operation.
 
 
+  gpgcheck="false"
+
+    Disable check of rpm signature, for all yum repositories
+    (`gpgcheck=0` in `yum.conf`).  Don't use this for a production
+    server.
+
+    Validity: any <installation> operation.
+
+
 Common Elements
 ---------------
 

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -33,6 +33,19 @@ Restore:
   ...
 </restore>
 
+
+Common Attributes
+-----------------
+
+  repo-gpgcheck="false"
+
+    Disable check of repodata signature, for all yum repositories
+    (`repo_gpgcheck=0` in `yum.conf`).  Don't use this for a network
+    install of a production server.
+
+    Validity: any <installation> operation.
+
+
 Common Elements
 ---------------
 

--- a/install.py
+++ b/install.py
@@ -145,6 +145,10 @@ def go(ui, args, answerfile_address, answerfile_script):
         elif opt == "--netinstall":
             results['netinstall'] = True
             logger.log("This is a netinstall.")
+        # XCP-ng: no-repo-gpgcheck
+        elif opt == "--no-repo-gpgcheck":
+            results['no-repo-gpgcheck'] = True
+            logger.log("No gpg check for yum repository.")
 
     if boot_console and not serial_console:
         serial_console = boot_console

--- a/install.py
+++ b/install.py
@@ -147,8 +147,12 @@ def go(ui, args, answerfile_address, answerfile_script):
             logger.log("This is a netinstall.")
         # XCP-ng: no-repo-gpgcheck
         elif opt == "--no-repo-gpgcheck":
-            results['no-repo-gpgcheck'] = True
-            logger.log("No gpg check for yum repository.")
+            results['repo-gpgcheck'] = False
+            logger.log("Commandline: no gpg check for yum repository.")
+        # XCP-ng: no-gpgcheck
+        elif opt == "--no-gpgcheck":
+            results['gpgcheck'] = False
+            logger.log("Commandline: no yum gpg check.")
 
     if boot_console and not serial_console:
         serial_console = boot_console

--- a/repository.py
+++ b/repository.py
@@ -254,6 +254,7 @@ class MainYumRepository(YumRepositoryWithInfo):
         super(MainYumRepository, self).__init__(accessor)
         self._identifier = MAIN_REPOSITORY_NAME
         self.keyfiles = []
+        self.__gpg_check = True
         self.__repo_gpg_check = True
 
         def get_name_version(config_parser, section, name_key, vesion_key):
@@ -325,10 +326,11 @@ class MainYumRepository(YumRepositoryWithInfo):
                 outfh = open(key_path, "w")
                 outfh.write(infh.read())
                 return """
-gpgcheck=1
+gpgcheck=%s
 repo_gpgcheck=%s
 gpgkey=file://%s
-""" % (1 if self.__repo_gpg_check else 0,
+""" % (1 if self.__gpg_check else 0,
+       1 if self.__repo_gpg_check else 0,
        key_path)
             finally:
                 if infh:
@@ -364,6 +366,9 @@ gpgkey=file://%s
         if self._build_number:
             branding['product-build'] = self._build_number
         return branding
+
+    def disableGpgCheck(self):
+        self.__gpg_check = False
 
     def disableRepoGpgCheck(self):
         self.__repo_gpg_check = False

--- a/repository.py
+++ b/repository.py
@@ -254,6 +254,7 @@ class MainYumRepository(YumRepositoryWithInfo):
         super(MainYumRepository, self).__init__(accessor)
         self._identifier = MAIN_REPOSITORY_NAME
         self.keyfiles = []
+        self.__repo_gpg_check = True
 
         def get_name_version(config_parser, section, name_key, vesion_key):
             name, version = None, None
@@ -325,9 +326,10 @@ class MainYumRepository(YumRepositoryWithInfo):
                 outfh.write(infh.read())
                 return """
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=%s
 gpgkey=file://%s
-""" % (key_path)
+""" % (1 if self.__repo_gpg_check else 0,
+       key_path)
             finally:
                 if infh:
                     infh.close()
@@ -363,6 +365,8 @@ gpgkey=file://%s
             branding['product-build'] = self._build_number
         return branding
 
+    def disableRepoGpgCheck(self):
+        self.__repo_gpg_check = False
 
 class UpdateYumRepository(YumRepositoryWithInfo):
     """Represents a Yum repository containing packages and associated meta data for an update."""


### PR DESCRIPTION
Those two `gpgcheck` and `repo-gpgcheck` flags, both declined in boot-parameter variant (`--no-gpgcheck`) and answerfile variant (`<installation gpgcheck="false">`), are meant as a quick replacement for the single `<installation netinstall-gpg-check>` parameter in xcp-ng 8.2.1, which was part of c86d2ac1db8a15d537fb9cea9e629a868d318ecf.