### PR TITLE
Global and per-source gpgcheck flags

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -269,7 +269,21 @@ class Answerfile:
             if rtype == 'url':
                 address = util.URL(address)
 
-            results['sources'].append({'media': rtype, 'address': address})
+            # workaround getBoolAttribute() not allowing "None" as
+            # default, by using a getStrAttribute() call first to
+            # handle the default situation where the attribute is not
+            # specified
+            repo_gpgcheck = (None if getStrAttribute(i, ['repo-gpgcheck'], default=None) is None
+                             else getBoolAttribute(i, ['repo-gpgcheck']))
+            gpgcheck = (None if getStrAttribute(i, ['gpgcheck'], default=None) is None
+                        else getBoolAttribute(i, ['gpgcheck']))
+
+            results['sources'].append({
+                'media': rtype, 'address': address,
+                'repo_gpgcheck': repo_gpgcheck,
+                'gpgcheck': gpgcheck,
+            })
+            logger.log("parsed source %s" % results['sources'][-1])
 
         return results
 

--- a/answerfile.py
+++ b/answerfile.py
@@ -93,6 +93,7 @@ class Answerfile:
                 raise AnswerfileException("Unknown mode, %s" % install_type)
 
             results['repo-gpgcheck'] = getBoolAttribute(self.top_node, ['repo-gpgcheck'], default=True)
+            results['gpgcheck'] = getBoolAttribute(self.top_node, ['gpgcheck'], default=True)
             results.update(self.parseCommon())
         elif self.operation == 'restore':
             results = self.parseRestore()

--- a/answerfile.py
+++ b/answerfile.py
@@ -92,6 +92,7 @@ class Answerfile:
             else:
                 raise AnswerfileException("Unknown mode, %s" % install_type)
 
+            results['repo-gpgcheck'] = getBoolAttribute(self.top_node, ['repo-gpgcheck'], default=True)
             results.update(self.parseCommon())
         elif self.operation == 'restore':
             results = self.parseRestore()

--- a/backend.py
+++ b/backend.py
@@ -403,8 +403,10 @@ def performInstallation(answers, ui_package, interactive):
         for i in answers_pristine['sources']:
             repos = repository.repositoriesFromDefinition(i['media'], i['address'])
             add_repos(main_repositories, update_repositories, repos)
-            repo_gpgcheck = answers.get('repo-gpgcheck', True)
-            gpgcheck = answers.get('gpgcheck', True)
+            repo_gpgcheck = (answers.get('repo-gpgcheck', True) if i['repo_gpgcheck'] is None
+                             else i['repo_gpgcheck'])
+            gpgcheck = (answers.get('gpgcheck', True) if i['gpgcheck'] is None
+                        else i['gpgcheck'])
             for repo in repos:
                 if repo in main_repositories:
                     repo.setRepoGpgCheck(repo_gpgcheck)

--- a/backend.py
+++ b/backend.py
@@ -404,9 +404,11 @@ def performInstallation(answers, ui_package, interactive):
             repos = repository.repositoriesFromDefinition(i['media'], i['address'])
             add_repos(main_repositories, update_repositories, repos)
             repo_gpgcheck = answers.get('repo-gpgcheck', True)
+            gpgcheck = answers.get('gpgcheck', True)
             for repo in repos:
                 if repo in main_repositories:
                     repo.setRepoGpgCheck(repo_gpgcheck)
+                    repo.setGpgCheck(gpgcheck)
 
     # A single source coming from an interactive install
     if 'source-media' in answers_pristine and 'source-address' in answers_pristine:

--- a/backend.py
+++ b/backend.py
@@ -403,6 +403,10 @@ def performInstallation(answers, ui_package, interactive):
         for i in answers_pristine['sources']:
             repos = repository.repositoriesFromDefinition(i['media'], i['address'])
             add_repos(main_repositories, update_repositories, repos)
+            repo_gpgcheck = answers.get('repo-gpgcheck', True)
+            for repo in repos:
+                if repo in main_repositories:
+                    repo.setRepoGpgCheck(repo_gpgcheck)
 
     # A single source coming from an interactive install
     if 'source-media' in answers_pristine and 'source-address' in answers_pristine:

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -88,6 +88,15 @@ Common Elements
       file:///path/
       nfs://server:/path/
 
+    Optional attributes for <source> only:
+
+      repo-gpgcheck=bool
+      gpgcheck=bool
+
+        Override the global yum gpgcheck setting, respectively for
+        repodata and RPMs, for this source only.  Only applies to
+        repositories that are not Supplemental Packs (none of which
+        are checked).
 
   <bootloader location="mbr|partition">grub2|extlinux[D]|grub[D]</bootloader>?
 

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -33,6 +33,21 @@ Restore:
   ...
 </restore>
 
+
+Common Attributes
+-----------------
+
+  repo-gpgcheck="false"
+
+    Disable check of repodata signature (`repo_gpgcheck=0` in
+    `yum.conf`), for all yum repositories that are not Supplemental
+    Packs (none of which are checked). Don't use this for a network
+    install of a production server, and make sure to verify the
+    authenticity of your install media through other means.
+
+    Validity: any <installation> operation.
+
+
 Common Elements
 ---------------
 

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -48,6 +48,15 @@ Common Attributes
     Validity: any <installation> operation.
 
 
+  gpgcheck="false"
+
+    Disable check of rpm signature (`gpgcheck=0` in `yum.conf`), for
+    all yum repositories that are not Supplemental Packs (none of
+    which are checked). Don't use this for a production server.
+
+    Validity: any <installation> operation.
+
+
 Common Elements
 ---------------
 

--- a/doc/parameters.txt
+++ b/doc/parameters.txt
@@ -221,3 +221,8 @@ Installer
   --no-repo-gpgcheck
 
     Disable check of repodata signature, for all yum repositories.
+
+
+  --no-gpgcheck
+
+    Disable check of rpm signature, for all yum repositories.

--- a/doc/parameters.txt
+++ b/doc/parameters.txt
@@ -216,3 +216,8 @@ Installer
   --cc-preparations
 
     Prepare configuration for common criteria security.
+
+
+  --no-repo-gpgcheck
+
+    Disable check of repodata signature, for all yum repositories.

--- a/install.py
+++ b/install.py
@@ -136,6 +136,9 @@ def go(ui, args, answerfile_address, answerfile_script):
         elif opt == "--netinstall":
             results['netinstall'] = True
             logger.log("This is a netinstall.")
+        elif opt == "--no-repo-gpgcheck":
+            results['repo-gpgcheck'] = False
+            logger.log("Yum gpg check of repository disabled on command-line")
 
     if boot_console and not serial_console:
         serial_console = boot_console

--- a/install.py
+++ b/install.py
@@ -139,6 +139,9 @@ def go(ui, args, answerfile_address, answerfile_script):
         elif opt == "--no-repo-gpgcheck":
             results['repo-gpgcheck'] = False
             logger.log("Yum gpg check of repository disabled on command-line")
+        elif opt == "--no-gpgcheck":
+            results['gpgcheck'] = False
+            logger.log("Yum gpg check of RPMs disabled on command-line")
 
     if boot_console and not serial_console:
         serial_console = boot_console

--- a/repository.py
+++ b/repository.py
@@ -244,6 +244,7 @@ class MainYumRepository(YumRepositoryWithInfo):
         super(MainYumRepository, self).__init__(accessor)
         self._identifier = MAIN_REPOSITORY_NAME
         self.keyfiles = []
+        self._repo_gpg_check = True
 
         def get_name_version(config_parser, section, name_key, vesion_key):
             name, version = None, None
@@ -315,9 +316,9 @@ class MainYumRepository(YumRepositoryWithInfo):
                 outfh.write(infh.read())
                 return """
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=%s
 gpgkey=file://%s
-""" % (key_path)
+""" % (int(self._repo_gpg_check), key_path)
             finally:
                 if infh:
                     infh.close()
@@ -353,6 +354,9 @@ gpgkey=file://%s
             branding['product-build'] = self._build_number
         return branding
 
+    def setRepoGpgCheck(self, value):
+        logger.log("%s: setRepoGpgCheck(%s)" % (self, value))
+        self._repo_gpg_check = value
 
 class UpdateYumRepository(YumRepositoryWithInfo):
     """Represents a Yum repository containing packages and associated meta data for an update."""

--- a/repository.py
+++ b/repository.py
@@ -245,6 +245,7 @@ class MainYumRepository(YumRepositoryWithInfo):
         self._identifier = MAIN_REPOSITORY_NAME
         self.keyfiles = []
         self._repo_gpg_check = True
+        self._gpg_check = True
 
         def get_name_version(config_parser, section, name_key, vesion_key):
             name, version = None, None
@@ -315,10 +316,10 @@ class MainYumRepository(YumRepositoryWithInfo):
                 outfh = open(key_path, "w")
                 outfh.write(infh.read())
                 return """
-gpgcheck=1
+gpgcheck=%s
 repo_gpgcheck=%s
 gpgkey=file://%s
-""" % (int(self._repo_gpg_check), key_path)
+""" % (int(self._gpg_check), int(self._repo_gpg_check), key_path)
             finally:
                 if infh:
                     infh.close()
@@ -357,6 +358,10 @@ gpgkey=file://%s
     def setRepoGpgCheck(self, value):
         logger.log("%s: setRepoGpgCheck(%s)" % (self, value))
         self._repo_gpg_check = value
+
+    def setGpgCheck(self, value):
+        logger.log("%s: setGpgCheck(%s)" % (self, value))
+        self._gpg_check = value
 
 class UpdateYumRepository(YumRepositoryWithInfo):
     """Represents a Yum repository containing packages and associated meta data for an update."""


### PR DESCRIPTION
Those two `gpgcheck` and `repo-gpgcheck` flags, both declined in boot-parameter variant (`--no-gpgcheck`) and answerfile variant (`<installation gpgcheck="false">`), are meant as a replacement for the single `<installation netinstall-gpg-check>` parameter in xcp-ng 8.2.1, which was part of c86d2ac1db8a15d537fb9cea9e629a868d318ecf.

- more accurate naming than the original (was never restricted to netinstall)
- more fine-grained control, no need to remove checking of rpms when you just add new or update signed RPMs into the repo