### PR TITLE
Keep `xen-pciback.hide` when upgrading

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -326,6 +326,10 @@ def performInstallation(answers, ui_package, interactive):
             # Set scheduler granularity if necessary.
             if 'sched-gran' in answers['host-config']:
                 default_host_config['sched-gran'] = answers['host-config']['sched-gran']
+
+            # Set xen-pciback if necessary.
+            if 'xen-pciback.hide' in answers['host-config']:
+                default_host_config['xen-pciback.hide'] = answers['host-config']['xen-pciback.hide']
         except Exception as e:
             logger.logException(e)
             raise RuntimeError("Failed to get existing installation settings")
@@ -1046,6 +1050,9 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
 
     common_kernel_params = "root=LABEL=%s ro nolvm hpet=disable" % constants.rootfs_label%disk_label_suffix
     kernel_console_params = "console=hvc0"
+
+    if "xen-pciback.hide" in host_config:
+        common_kernel_params += " %s" % host_config["xen-pciback.hide"]
 
     if diskutil.is_iscsi(primary_disk):
         common_kernel_params += " rd.iscsi.ibft=1 rd.iscsi.firmware=1"

--- a/product.py
+++ b/product.py
@@ -382,7 +382,7 @@ class ExistingInstallation:
             if sched_gran:
                 results['host-config']['sched-gran'] = sched_gran
 
-            # Subset of hypervisor arguments
+            # Subset of dom0 kernel arguments
             kernel_args = boot_config.menu[boot_config.default].getKernelArgs()
 
             #   - xen-pciback.hide

--- a/product.py
+++ b/product.py
@@ -381,6 +381,15 @@ class ExistingInstallation:
             sched_gran = next((x for x in xen_args if x.startswith('sched-gran=')), None)
             if sched_gran:
                 results['host-config']['sched-gran'] = sched_gran
+
+            # Subset of hypervisor arguments
+            kernel_args = boot_config.menu[boot_config.default].getKernelArgs()
+
+            #   - xen-pciback.hide
+            pciback = next((x for x in kernel_args if x.startswith('xen-pciback.hide=')), None)
+            if pciback:
+                results['host-config']['xen-pciback.hide'] = pciback
+
         except:
             pass
         self.unmount_boot()


### PR DESCRIPTION
Get `xen-pciback.hide` from a host's kernel's args 
Give it to the bootloader after the upgrade

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>