### PR TITLE
Hide supplemental-pack feature behind a feature flag

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -418,7 +418,7 @@ def performInstallation(answers, ui_package, interactive):
         if r.accessor().canEject():
             r.accessor().eject()
 
-    if interactive:
+    if interactive and constants.HAS_SUPPLEMENTAL_PACKS:
         # Add supp packs in a loop
         while True:
             media_ans = dict(answers_pristine)

--- a/constants.py
+++ b/constants.py
@@ -181,3 +181,7 @@ INIT_SERVICE_FILES = [
     'var/lib/misc/ran-network-init',
     'var/lib/misc/ran-storage-init',
 ]
+
+# optional features
+FEATURES_DIR = "/etc/xensource/features"
+HAS_SUPPLEMENTAL_PACKS = os.path.exists(os.path.join(FEATURES_DIR, "supplemental-packs"))

--- a/doc/features.txt
+++ b/doc/features.txt
@@ -1,0 +1,16 @@
+Features flags
+==============
+
+Some host-installer features are not enabled by default, and
+downstream installers can activate them by creating a file in
+/etc/xensource/features/ in their installer filesystem.
+
+Currently available feature flags are:
+
+  supplemental-packs
+
+    Support installation of supplemental packs after installation of
+    the main product.
+
+    This only impacts the UI, the <source> answerfile construct still
+    allows to include supplemental packs without this feature flag.


### PR DESCRIPTION
Not touching this branch as it is also the source of https://github.com/xenserver/host-installer/pull/28.

Merge is available in branch next as 4308d25fd03d282f074e05a53a66102c6110d580.