### PR TITLE
Keep user multipath configuration upon upgrade

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -451,6 +451,9 @@ class ThirdGenUpgrader(Upgrader):
         # Keep IPv6 enablement/disablement upon upgrades
         self.restore_list += ['etc/sysctl.d/91-net-ipv6.conf']
 
+        # Keep user multipath configuration
+        self.restore_list += [{'dir': 'etc/multipath/conf.d', 're': r'custom.*\.conf'}]
+
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']
     def completeUpgrade(self, mounts, prev_install, target_disk, backup_partnum, logs_partnum, admin_iface, admin_bridge, admin_config):
 


### PR DESCRIPTION
All files matchin `custom.*\.conf` will be kept
upon upgrade.

See: https://github.com/xapi-project/sm/pull/600