### PR TITLE
fixup! Keep user multipath configuration upon upgrade

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -449,7 +449,7 @@ class ThirdGenUpgrader(Upgrader):
         self.restore_list += ['etc/nagios/nrpe.cfg', {'dir': 'etc/nrpe.d'}]
 
         # Keep user multipath configuration
-        self.restore_list += [{'dir': 'etc/multipath/conf.d', 're': r'custom.*\.conf'}]
+        self.restore_list += [{'dir': 'etc/multipath/conf.d', 're': re.compile(r'custom.*\.conf')}]
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']
     def completeUpgrade(self, mounts, prev_install, target_disk, backup_partnum, logs_partnum, admin_iface, admin_bridge, admin_config):


### PR DESCRIPTION
're' key in restore_list takes a compiled regexp, not a string.

problem not detected in #22 