### PR TITLE
Make the unsupported / for-troubleshooting status of kernel-alt more obvious

### DIFF
--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -46,7 +46,9 @@ def kernel_warning(answers):
             "Alternate kernel",
             """WARNING: you chose to install our alternative kernel (kernel-alt).
 
-It is based on our main kernel + upstream kernel.org patches, so it should be stable by construction. However it receives less testing than the main kernel.
+This kernel is only provided for debugging purposes.
+
+It is based on our main kernel + upstream kernel.org patches, so it should be stable by construction. However it receives less testing than the main kernel, and is not security-supported.
 
 A boot menu entry for kernel-alt will be added, but we will still boot the main kernel by default.
 


### PR DESCRIPTION
This is a squash commit that will end up rerolled in the `small-patches` branch