### PR TITLE
disktool: Optionally dump old/new partitions during commit

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -703,6 +703,8 @@ class PartitionToolBase:
             yield number, partition
 
     def commit(self, dryrun=False, log=False):
+        if log:
+            self.dump()
         self.writePartitionTable(dryrun, log)
         if not dryrun:
             # Update the revert point so this tool can be used repeatedly
@@ -717,12 +719,12 @@ class PartitionToolBase:
         for number, partition in sorted(self.origPartitions.items()):
             output += "Old partition "+str(number)+":"
             for k, v in sorted(partition.items()):
-                output += ' '+k+'='+((k == 'id') and hex(v) or str(v))
+                output += ' '+k+'='+((k == 'id' and type(v) == int) and hex(v) or str(v))
             output += "\n"
         for number, partition in sorted(self.partitions.items()):
             output += "New partition "+str(number)+":"
             for k, v in sorted(partition.items()):
-                output += ' '+k+'='+((k == 'id') and hex(v) or str(v))
+                output += ' '+k+'='+((k == 'id' and type(v) == int) and hex(v) or str(v))
             output += "\n"
         logger.log(output)
 


### PR DESCRIPTION
While digging for the problem mentioned in https://github.com/xenserver/host-installer/pull/155 I had to fix this dump() for GPT support. Finally realized that this has been fixed in master already.

Port of xenserver#156 for xcp-ng 8.3.0