### PR TITLE
Upgrade: forbid upgrading with a key XAPI will reject

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -194,3 +194,6 @@ try:
             SR_TYPE_LARGE_BLOCK = value
 except IOError:
     pass
+
+# crypto configuration
+MIN_KEY_SIZE = 2048

--- a/upgrade.py
+++ b/upgrade.py
@@ -234,7 +234,10 @@ class ThirdGenUpgrader(Upgrader):
         if tool.partTableType == constants.PARTITION_DOS and utilparts is not None:
             raise RuntimeError("Util partition detected on DOS partition type, upgrade forbidden.")
         if self.key_size < constants.MIN_KEY_SIZE:
-            raise RuntimeError("Current server certificate is too small (%s bits), please regenerate with at least %s bits." % (self.key_size, constants.MIN_KEY_SIZE))
+            raise RuntimeError("Current server certificate is too small (%s bits),"
+                               " please regenerate with at least %s bits.\n\n"
+                               "See the Release Notes for XCP-ng 8.3.0" %
+                               (self.key_size, constants.MIN_KEY_SIZE))
 
     convertTargetStateChanges = []
     convertTargetArgs = ['primary-disk', 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum', 'backup-partnum']


### PR DESCRIPTION
XAPI now rejects the default keysize of 7.x era, which must be regenerated before upgrading to 8.3.  Let the installer refuse to initiate a situation where a Rolling Pool Upgrade would be unable to proceed, with not-yet-updated slaves holding the running VMs getting refused connection to the updated part of the pool.

Results in this failure, but only after the user gave authorization to write the backup:

![cert-too-small](https://github.com/user-attachments/assets/b3c8c064-c720-48cb-9f07-a1db62fb75ec)

Submitted upstream as https://github.com/xenserver/host-installer/pull/167