### PR TITLE
Linstor upgrade from 8.2.1 to 8.3

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -158,7 +158,7 @@ def getPrepSequence(ans, interactive):
 
 def getMainRepoSequence(ans, repos):
     seq = []
-    seq.append(Task(repository.installFromRepos, lambda a: [repos] + [a.get('mounts')], [],
+    seq.append(Task(repository.installFromRepos, lambda a: [repos] + [a.get('mounts'), a.get('linstor-version')], [],
                 progress_scale=100,
                 pass_progress_callback=True,
                 progress_text="Installing %s..." % (", ".join([repo.name() for repo in repos]))))

--- a/backend.py
+++ b/backend.py
@@ -412,6 +412,21 @@ def performInstallation(answers, ui_package, interactive):
     answers_pristine = answers.copy()
     determineRepositories(answers, answers_pristine, main_repositories, update_repositories)
 
+    # if upgrading a host with LINSTOR, check we can upgrade it first
+    if answers['install-type'] == INSTALL_TYPE_REINSTALL and answers['linstor-version']:
+        available_linstor_versions = repository.listPackagesFromRepos(
+            main_repositories, 'linstor-satellite', '%{evr}')
+        if not available_linstor_versions:
+            raise RuntimeError("Cannot upgrade host with LINSTOR using a package source "
+                               "that does not have LINSTOR.  Please use as package source the "
+                               "repository on the dedicated ISO.")
+        if answers['linstor-version'] not in available_linstor_versions:
+            raise RuntimeError("Cannot upgrade host with LINSTOR %s, "
+                               "upgrade repository has versions: %s.  "
+                               "Please make sure your pool is uptodate and use the "
+                               "latest dedicated ISO." %
+                               (answers['linstor-version'], ', '.join(available_linstor_versions)))
+
     # perform installation:
     prep_seq = getPrepSequence(answers, interactive)
     executeSequence(prep_seq, "Preparing for installation...", answers, ui_package, False)

--- a/product.py
+++ b/product.py
@@ -28,6 +28,14 @@ THIS_PLATFORM_VERSION = Version.from_string(version.PLATFORM_VERSION)
 XENSERVER_7_0_0 = Version([2, 1, 0]) # Platform version
 XENSERVER_MIN_VERSION = XENSERVER_7_0_0
 
+def getLinstorVersion(rootfs_mount):
+    """ Returns the package version of the LINSTOR packages if any """
+    command = ['rpm', '--root', rootfs_mount, '-q', '--qf', '%{evr}', 'linstor-satellite']
+    rc, out = util.runCmd2(command, with_stdout=True)
+    if rc != 0:
+        return None
+    return out
+
 class ExistingInstallation:
     def __init__(self, primary_disk, boot_device, state_device):
         self.primary_disk = primary_disk
@@ -355,6 +363,9 @@ class ExistingInstallation:
                 pc.close()
             except:
                 pass
+
+            results['linstor-version'] = getLinstorVersion(self.state_fs.mount_point) or None
+            logger.info("LINSTOR version detected: %s" % (results['linstor-version'],))
 
         finally:
             self.unmount_state()

--- a/repository.py
+++ b/repository.py
@@ -882,3 +882,30 @@ def installFromRepos(progress_callback, repos, mounts, linstor_version):
     finally:
         for repo in repos:
             repo._accessor.finish()
+
+# unlike modern dnf, silly yum in el7 does not hide "0:" in "%{evr}"
+NULL_EPOCH_RE = re.compile(r"(.*)\b0:(.*)$")
+def hideNullEpoch(package):
+    m = re.match(NULL_EPOCH_RE, package)
+    if not m:
+        return package
+    return "".join(m.groups())
+
+def listPackagesFromRepos(repos, rpm_pattern, query_format='%{nevr}'):
+    cachedir = "var/cache/yum/installer"
+    yum_conf_path = '/root/yum.conf'
+
+    for repo in repos:
+        repo._accessor.start()
+
+    try:
+        createMainYumConfig(yum_conf_path, repos, cachedir)
+
+        rv, out = util.runCmd2(['repoquery', '-c', yum_conf_path,
+                                '--qf', query_format,
+                                rpm_pattern], with_stdout=True)
+    finally:
+        for repo in repos:
+            repo._accessor.finish()
+
+    return [hideNullEpoch(package) for package in out.split()]

--- a/repository.py
+++ b/repository.py
@@ -187,7 +187,7 @@ class YumRepository(Repository):
         assert self._targets is not None
         url = self._accessor.url()
         logger.log("URL: " + str(url))
-        yum_conf_path = '/root/yum.conf'
+        yum_conf_path = '/root/yum-%s.conf' % (self._identifier,)
         with open(yum_conf_path, 'w') as yum_conf:
             yum_conf.write(self._yum_conf)
             yum_conf.write("""
@@ -419,7 +419,7 @@ history_record=false
     def isRepo(cls, accessor):
         if UpdateYumRepository.isRepo(accessor):
             url = accessor.url()
-            yum_conf_path = '/root/yum.conf'
+            yum_conf_path = '/root/yum-driverrepo.conf'
             with open(yum_conf_path, 'w') as yum_conf:
                 yum_conf.write(cls._yum_conf)
                 yum_conf.write("""

--- a/repository.py
+++ b/repository.py
@@ -833,6 +833,26 @@ def installFromYum(yum_conf_path, targets, mounts, progress_callback, cachedir):
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))
 
+def createMainYumConfig(yum_conf_path, repos, cachedir):
+    with open(yum_conf_path, 'w') as yum_conf:
+        yum_conf.write(_generateYumConf(cachedir))
+        for repo in repos:
+            url = repo._accessor.url()
+            yum_conf.write("""
+[%s]
+name=%s
+baseurl=%s
+""" % (repo.identifier(), repo.identifier(), url.getPlainURL()))
+            username = url.getUsername()
+            if username is not None:
+                yum_conf.write("username=%s\n" % (url.getUsername(),))
+            password = url.getPassword()
+            if password is not None:
+                yum_conf.write("password=%s\n" % (url.getPassword(),))
+            repo_config = repo._repo_config()
+            if repo_config is not None:
+                yum_conf.write(repo_config)
+
 def installFromRepos(progress_callback, repos, mounts, linstor_version):
     """Install from a stacked set of repositories"""
 
@@ -843,26 +863,7 @@ def installFromRepos(progress_callback, repos, mounts, linstor_version):
         repo._accessor.start()
 
     try:
-        # Build a yum config
-        with open(yum_conf_path, 'w') as yum_conf:
-            yum_conf.write(_generateYumConf(cachedir))
-            for repo in repos:
-                url = repo._accessor.url()
-                yum_conf.write("""
-[%s]
-name=%s
-baseurl=%s
-""" % (repo.identifier(), repo.identifier(), url.getPlainURL()))
-                username = url.getUsername()
-                if username is not None:
-                    yum_conf.write("username=%s\n" % (url.getUsername(),))
-                password = url.getPassword()
-                if password is not None:
-                    yum_conf.write("password=%s\n" % (url.getPassword(),))
-                repo_config = repo._repo_config()
-                if repo_config is not None:
-                    yum_conf.write(repo_config)
-
+        createMainYumConfig(yum_conf_path, repos, cachedir)
 
         repos[0].disableInitrdCreation(mounts['root'])
         targets = []

--- a/repository.py
+++ b/repository.py
@@ -831,7 +831,7 @@ def installFromYum(targets, mounts, progress_callback, cachedir):
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))
 
-def installFromRepos(progress_callback, repos, mounts):
+def installFromRepos(progress_callback, repos, mounts, linstor_version):
     """Install from a stacked set of repositories"""
 
     cachedir = "var/cache/yum/installer"
@@ -866,6 +866,11 @@ baseurl=%s
             if repo._targets:
                 targets += repo._targets
         targets = list(set(targets))
+        if linstor_version:
+            targets.extend(['xcp-ng-release-linstor', 'xcp-ng-linstor',
+                            'linstor-satellite-%s' % linstor_version,
+                            'linstor-controller-%s' % linstor_version,
+                            ])
 
         installFromYum(targets, mounts, progress_callback, cachedir)
         repos[0].enableInitrdCreation()

--- a/repository.py
+++ b/repository.py
@@ -187,7 +187,8 @@ class YumRepository(Repository):
         assert self._targets is not None
         url = self._accessor.url()
         logger.log("URL: " + str(url))
-        with open('/root/yum.conf', 'w') as yum_conf:
+        yum_conf_path = '/root/yum.conf'
+        with open(yum_conf_path, 'w') as yum_conf:
             yum_conf.write(self._yum_conf)
             yum_conf.write("""
 [install]
@@ -205,7 +206,7 @@ baseurl=%s
                 yum_conf.write(repo_config)
 
         self.disableInitrdCreation(mounts['root'])
-        installFromYum(self._targets, mounts, progress_callback, self._cachedir)
+        installFromYum(yum_conf_path, self._targets, mounts, progress_callback, self._cachedir)
         self.enableInitrdCreation()
 
     def installPackages(self, progress_callback, mounts):
@@ -418,7 +419,8 @@ history_record=false
     def isRepo(cls, accessor):
         if UpdateYumRepository.isRepo(accessor):
             url = accessor.url()
-            with open('/root/yum.conf', 'w') as yum_conf:
+            yum_conf_path = '/root/yum.conf'
+            with open(yum_conf_path, 'w') as yum_conf:
                 yum_conf.write(cls._yum_conf)
                 yum_conf.write("""
 [driverrepo]
@@ -433,7 +435,7 @@ baseurl=%s
                     yum_conf.write("password=%s\n" % (url.getPassword(),))
 
             # Check that the drivers group exists in the repo.
-            rv, out = util.runCmd2(['yum', '-c', '/root/yum.conf',
+            rv, out = util.runCmd2(['yum', '-c', yum_conf_path,
                                     'group', 'summary', 'drivers'], with_stdout=True)
             if rv == 0 and 'Groups: 1\n' in out.strip():
                 return True
@@ -784,11 +786,11 @@ def findRepositoriesOnMedia(drivers=False):
 
     return repos
 
-def installFromYum(targets, mounts, progress_callback, cachedir):
+def installFromYum(yum_conf_path, targets, mounts, progress_callback, cachedir):
         # Use a temporary file to avoid deadlocking
         stderr = tempfile.TemporaryFile()
 
-        yum_command = ['yum', '-c', '/root/yum.conf',
+        yum_command = ['yum', '-c', yum_conf_path,
                        '--installroot', mounts['root'],
                        'install', '-y'] + targets
         logger.log("Running yum: %s" % ' '.join(yum_command))
@@ -835,12 +837,14 @@ def installFromRepos(progress_callback, repos, mounts, linstor_version):
     """Install from a stacked set of repositories"""
 
     cachedir = "var/cache/yum/installer"
+    yum_conf_path = '/root/yum.conf'
+
     for repo in repos:
         repo._accessor.start()
 
     try:
         # Build a yum config
-        with open('/root/yum.conf', 'w') as yum_conf:
+        with open(yum_conf_path, 'w') as yum_conf:
             yum_conf.write(_generateYumConf(cachedir))
             for repo in repos:
                 url = repo._accessor.url()
@@ -872,7 +876,7 @@ baseurl=%s
                             'linstor-controller-%s' % linstor_version,
                             ])
 
-        installFromYum(targets, mounts, progress_callback, cachedir)
+        installFromYum(yum_conf_path, targets, mounts, progress_callback, cachedir)
         repos[0].enableInitrdCreation()
     finally:
         for repo in repos:

--- a/upgrade.py
+++ b/upgrade.py
@@ -683,6 +683,9 @@ class ThirdGenUpgrader(Upgrader):
         restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
         restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
 
+        # XAPI firewall-port plugin
+        restore_list += ['etc/sysconfig/iptables']
+
         return restore_list
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']

--- a/upgrade.py
+++ b/upgrade.py
@@ -183,7 +183,7 @@ class Upgrader(object):
             if not d: d = f
             src = os.path.join(src_base, f)
             dst = os.path.join(mounts['root'], d)
-            if os.path.exists(src):
+            if os.path.lexists(src):
                 logger.log("Restoring /%s" % f)
                 util.assertDir(os.path.dirname(dst))
                 # copy file/folder and try to preserve all attributes

--- a/upgrade.py
+++ b/upgrade.py
@@ -592,9 +592,9 @@ class ThirdGenUpgrader(Upgrader):
         finally:
             primary_fs.unmount()
 
-    prepUpgradeArgs = ['installation-uuid', 'control-domain-uuid']
+    prepUpgradeArgs = []
     prepStateChanges = ['installation-uuid', 'control-domain-uuid']
-    def prepareUpgrade(self, progress_callback, installID, controlID):
+    def prepareUpgrade(self, progress_callback):
         """ Try to preserve the installation and control-domain UUIDs from
         xensource-inventory."""
         try:

--- a/upgrade.py
+++ b/upgrade.py
@@ -593,7 +593,7 @@ class ThirdGenUpgrader(Upgrader):
             primary_fs.unmount()
 
     prepUpgradeArgs = []
-    prepStateChanges = ['installation-uuid', 'control-domain-uuid']
+    prepStateChanges = ['installation-uuid', 'control-domain-uuid', 'linstor-version']
     def prepareUpgrade(self, progress_callback):
         """ Try to preserve the installation and control-domain UUIDs from
         xensource-inventory."""
@@ -603,7 +603,7 @@ class ThirdGenUpgrader(Upgrader):
         except KeyError:
             raise RuntimeError("Required information (INSTALLATION_UUID, CONTROL_DOMAIN_UUID) was missing from your xensource-inventory file.  Aborting installation; please replace these keys and try again.")
 
-        return installID, controlID
+        return installID, controlID, self.source.settings['linstor-version']
 
     def buildRestoreList(self, src_base):
         restore_list = []

--- a/upgrade.py
+++ b/upgrade.py
@@ -683,6 +683,13 @@ class ThirdGenUpgrader(Upgrader):
         restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
         restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
 
+        # LINSTOR
+        restore_list += ['etc/drbd-reactor.d/sm-linstor.toml',
+                         'etc/systemd/system/multi-user.target.wants/drbd-reactor.service',
+                         'etc/systemd/system/multi-user.target.wants/linstor-satellite.service',
+                         'etc/systemd/system/multi-user.target.wants/linstor-monitor.service',
+                         ]
+
         # XAPI firewall-port plugin
         restore_list += ['etc/sysconfig/iptables']
 


### PR DESCRIPTION
This adds a first level of upgrade for a XOSTOR-enabled pool from 8.2.1 to 8.3.

- relies on a specific image including linstor packages compatible with the uptodate 8.2.1 we're upgrading, see https://github.com/xcp-ng/create-install-image/pull/27
- limitations:
  - no support yet for upgrade over network (HTTP, NFS)
  - user-friendly messages let the user determine when they need to update their linstor version when they need to fetch the latest iso (they are shown all package versions to determine that themselves)
- subset of full test scope covered:
  - nominal upgrade path tested both using TUI and answerfile
  - migrating a VM on xostor SR from 8.2 to upgraded 8.3

Design:
- in pre-upgrade checks
  - detect presence of `linstor-satellite` to trigger the mechanism
  - check the installed `linstor-satellite` versions match one shipped by the install source
- during rpm-install stage
  - request installation of matching `linstor-satellite` and `linstor-controller`, in addition to the standard `xcp-ng-linstor`
- during finalization stage, add to files to restore:
 - the iptables state saved by `firewall-port` plugin
  - `/etc/drbd-reactor.d/sm-linstor.toml`
  - systemd symlinks for activation of `linstor-satellite` and `drbd-reactor`

Note the branch starts with a few cleanups/fixes that should make their way into the tree first and separately.