### PR TITLE
yum: fail when a package for install is not found

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -101,6 +101,7 @@ installonlypkgs=
 distroverpkg=xenserver-release
 reposdir=/tmp/repos
 history_record=false
+skip_missing_names_on_install=0
 """ % cachedir
 
 _yumRepositoryId = 1


### PR DESCRIPTION
For some reason the default for yum when we specify a package not available in any repo, is to just print a note and proceeed. Which in the context of the installer is equivalent "silently ignore".