### PR TITLE
Bug fix - automatic software raid install using answerfile

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -134,7 +134,7 @@ class Answerfile:
         results['backup-existing-installation'] = False
 
         results.update(self.parseRaid())
-        results.update(self.parseDisks())
+        results.update(self.parseDisks(raid=results.get('raid', {})))
         results.update(self.parseInterface())
         results.update(self.parseRootPassword())
         results.update(self.parseNSConfig())
@@ -360,8 +360,14 @@ class Answerfile:
         large_block_disks = [
             disk
             for disk in guest_disks
-            if diskutil.isLargeBlockDisk(disk)
+            if disk not in raid and diskutil.isLargeBlockDisk(disk)
         ]
+        for disk in guest_disks:
+            if disk in raid:
+                for child in raid[disk]:
+                    if diskutil.isLargeBlockDisk(child):
+                        large_block_disks.append(disk)
+                        break
 
         if SR_TYPE_LARGE_BLOCK and len(large_block_disks) > 0:
             default_sr_type = SR_TYPE_LARGE_BLOCK


### PR DESCRIPTION
The bug in question happens when the code tries to check the logical_block_size of the md device that wasn't created yet. 
To reproduce the bug install xcp-ng via pxe and answerfile while using the raid drive as a primary drive and not turning off sr storage on said drive. 

Updated the way disks are parsed when selecting `SR_TYPE`, more specifically when checking disk block size to take into consideration software raid disks that hasn't been created yet.

This patch sends the results of `parseRaid()` into `parseDisk()` so that the md devices can be ignored in the initial check and have the device's children checked for block size instead, while still reporting the md device's future block size (since the code checks if the block size is over 512, if any children is over 512 then the md device when created later on must be over 512)

Example answerfile:
```xml
<?xml version="1.0"?>
    <installation mode="fresh" srtype="ext">
        <raid device="md127">
                <disk>vda</disk>
                <disk>vdb</disk>
        </raid>
        <primary-disk>md127</primary-disk>
        <keymap>us</keymap>
        <root-password>yesroot</root-password>
        <source type="url">http://192.168.120.2/xcp-ng/install/</source>
        <admin-interface name="eth0" proto="dhcp" />
        <timezone>Europe/Paris</timezone>
    </installation>
```