### PR TITLE
Rebase on top of 10.10.38 for 8.3

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -90,6 +90,7 @@ class Answerfile:
             else:
                 raise AnswerfileException("Unknown mode, %s" % install_type)
 
+            results['repo-gpgcheck'] = getBoolAttribute(self.top_node, ['repo-gpgcheck'], default=True)
             results.update(self.parseCommon())
         elif self.operation == 'restore':
             results = self.parseRestore()

--- a/answerfile.py
+++ b/answerfile.py
@@ -276,7 +276,21 @@ class Answerfile:
             if rtype == 'url':
                 address = util.URL(address)
 
-            results['sources'].append({'media': rtype, 'address': address})
+            # workaround getBoolAttribute() not allowing "None" as
+            # default, by using a getStrAttribute() call first to
+            # handle the default situation where the attribute is not
+            # specified
+            repo_gpgcheck = (None if getStrAttribute(i, ['repo-gpgcheck'], default=None) is None
+                             else getBoolAttribute(i, ['repo-gpgcheck']))
+            gpgcheck = (None if getStrAttribute(i, ['gpgcheck'], default=None) is None
+                        else getBoolAttribute(i, ['gpgcheck']))
+
+            results['sources'].append({
+                'media': rtype, 'address': address,
+                'repo_gpgcheck': repo_gpgcheck,
+                'gpgcheck': gpgcheck,
+            })
+            logger.log("parsed source %s" % results['sources'][-1])
 
         return results
 

--- a/answerfile.py
+++ b/answerfile.py
@@ -91,6 +91,7 @@ class Answerfile:
                 raise AnswerfileException("Unknown mode, %s" % install_type)
 
             results['repo-gpgcheck'] = getBoolAttribute(self.top_node, ['repo-gpgcheck'], default=True)
+            results['gpgcheck'] = getBoolAttribute(self.top_node, ['gpgcheck'], default=True)
             results.update(self.parseCommon())
         elif self.operation == 'restore':
             results = self.parseRestore()

--- a/answerfile.py
+++ b/answerfile.py
@@ -332,7 +332,20 @@ class Answerfile:
                                                             default='if-utility')
         results['swraid'] = getBoolAttribute(node, ['swraid'], default=False)
 
-        if results['swraid']:
+        # "legacy" XCP-ng RAID definition
+        legacy_raid = {}
+        for raid_node in getElementsByTagName(self.top_node, ['raid']):
+            disk_device = normalize_disk(getStrAttribute(raid_node, ['device'], mandatory=True))
+            disks = [normalize_disk(getText(node)) for node in getElementsByTagName(raid_node, ['disk'])]
+            legacy_raid[disk_device] = disks
+
+        if legacy_raid:
+            assert len(legacy_raid) == 1, "Building more than one RAID is no supported any more"
+            # FIXME: the following be problematic, legacy raid had implicit localhost:127 name
+            results['primary-disk'] = ""  # Populated with disk-label-suffix during installer prep
+            results['physical-disks'] = next(iter(legacy_raid.values()))
+            results['swraid'] = True
+        elif results['swraid']:
             disks = getText(node).split(",")
             if len(disks) != 2:
                 raise AnswerfileException("swraid primary-disk requires exactly two physical disks")

--- a/answerfile.py
+++ b/answerfile.py
@@ -380,7 +380,7 @@ class Answerfile:
         if SR_TYPE_LARGE_BLOCK and len(large_block_disks) > 0:
             default_sr_type = SR_TYPE_LARGE_BLOCK
         else:
-            default_sr_type = SR_TYPE_LVM
+            default_sr_type = SR_TYPE_EXT
 
         sr_type = getMapAttribute(self.top_node,
                                   ['sr-type', 'srtype'],

--- a/backend.py
+++ b/backend.py
@@ -320,7 +320,7 @@ def executeSequence(sequence, seq_name, answers, ui, cleanup):
             del answers['cleanup']
 
 def determineRepositories(answers, answers_pristine, main_repositories, update_repositories):
-    def add_repos(main_repositories, update_repositories, repos):
+    def add_repos(main_repositories, update_repositories, repos, repo_gpgcheck, gpgcheck):
         """Add repositories to the appropriate list, ensuring no duplicates,
         that the main repository is at the beginning, and that the order of the
         rest is maintained."""
@@ -337,28 +337,28 @@ def determineRepositories(answers, answers_pristine, main_repositories, update_r
                 else:
                     repo_list.append(repo)
 
+                if repo_list is main_repositories: # i.e., if repo is a "main repository"
+                    repo.setRepoGpgCheck(repo_gpgcheck)
+                    repo.setGpgCheck(gpgcheck)
+
+    default_repo_gpgcheck = answers.get('repo-gpgcheck', True)
+    default_gpgcheck = answers.get('gpgcheck', True)
     # A list of sources coming from the answerfile
     if 'sources' in answers_pristine:
         for i in answers_pristine['sources']:
             repos = repository.repositoriesFromDefinition(i['media'], i['address'])
-            add_repos(main_repositories, update_repositories, repos)
-            repo_gpgcheck = (answers.get('repo-gpgcheck', True) if i['repo_gpgcheck'] is None
-                             else i['repo_gpgcheck'])
-            gpgcheck = (answers.get('gpgcheck', True) if i['gpgcheck'] is None
-                        else i['gpgcheck'])
-            for repo in repos:
-                if repo in main_repositories:
-                    repo.setRepoGpgCheck(repo_gpgcheck)
-                    repo.setGpgCheck(gpgcheck)
+            repo_gpgcheck = default_repo_gpgcheck if i['repo_gpgcheck'] is None else i['repo_gpgcheck']
+            gpgcheck = default_gpgcheck if i['gpgcheck'] is None else i['gpgcheck']
+            add_repos(main_repositories, update_repositories, repos, repo_gpgcheck, gpgcheck)
 
     # A single source coming from an interactive install
     if 'source-media' in answers_pristine and 'source-address' in answers_pristine:
         repos = repository.repositoriesFromDefinition(answers_pristine['source-media'], answers_pristine['source-address'])
-        add_repos(main_repositories, update_repositories, repos)
+        add_repos(main_repositories, update_repositories, repos, default_repo_gpgcheck, default_gpgcheck)
 
     for media, address in answers_pristine['extra-repos']:
         repos = repository.repositoriesFromDefinition(media, address)
-        add_repos(main_repositories, update_repositories, repos)
+        add_repos(main_repositories, update_repositories, repos, default_repo_gpgcheck, default_gpgcheck)
 
     if not main_repositories or main_repositories[0].identifier() != MAIN_REPOSITORY_NAME:
         raise RuntimeError("No main repository found")

--- a/backend.py
+++ b/backend.py
@@ -105,6 +105,7 @@ def getPrepSequence(ans, interactive):
     seq = [
         Task(util.getUUID, As(ans), ['installation-uuid']),
         Task(util.getUUID, As(ans), ['control-domain-uuid']),
+        Task(util.getMgmtAddrType, As(ans), ['management-address-type']),
         Task(util.randomLabelStr, As(ans), ['disk-label-suffix']),
         ]
 
@@ -197,7 +198,7 @@ def getFinalisationSequence(ans):
         Task(writeFstab, A(ans, 'mounts', 'target-boot-mode', 'primary-disk', 'logs-partnum', 'swap-partnum', 'disk-label-suffix'), []),
         Task(enableAgent, A(ans, 'mounts', 'network-backend', 'services'), []),
         Task(configureCC, A(ans, 'mounts'), []),
-        Task(writeInventory, A(ans, 'installation-uuid', 'control-domain-uuid', 'mounts', 'primary-disk',
+        Task(writeInventory, A(ans, 'installation-uuid', 'control-domain-uuid', 'management-address-type', 'mounts', 'primary-disk',
                                'backup-partnum', 'logs-partnum', 'boot-partnum', 'swap-partnum', 'storage-partnum',
                                'guest-disks', 'net-admin-bridge',
                                'branding', 'net-admin-configuration', 'host-config', 'install-type'), []),
@@ -1685,7 +1686,7 @@ def writeXencommons(controlID, mounts):
     with open(os.path.join(mounts['root'], constants.XENCOMMONS_FILE), "w") as f:
         f.write(contents)
 
-def writeInventory(installID, controlID, mounts, primary_disk, backup_partnum, logs_partnum, boot_partnum, swap_partnum,
+def writeInventory(installID, controlID, mgmtAddrType, mounts, primary_disk, backup_partnum, logs_partnum, boot_partnum, swap_partnum,
                    storage_partnum, guest_disks, admin_bridge, branding, admin_config, host_config, install_type):
     inv = open(os.path.join(mounts['root'], constants.INVENTORY_FILE), "w")
     if 'product-brand' in branding:
@@ -1735,11 +1736,16 @@ def writeInventory(installID, controlID, mounts, primary_disk, backup_partnum, l
     inv.write("DOM0_MEM='%d'\n" % host_config['dom0-mem'])
     inv.write("DOM0_VCPUS='%d'\n" % host_config['dom0-vcpus'])
     inv.write("MANAGEMENT_INTERFACE='%s'\n" % admin_bridge)
-    # Default to IPv4 unless we have only got an IPv6 admin interface
-    if ((not admin_config.mode) and admin_config.modev6):
-        inv.write("MANAGEMENT_ADDRESS_TYPE='IPv6'\n")
+    # If we read MANAGEMENT_ADDRESS_TYPE from xensource-inventory use it
+    if mgmtAddrType:
+        # On upgrade, persist value read from install
+        inv.write("MANAGEMENT_ADDRESS_TYPE='%s'\n" % mgmtAddrType)
     else:
-        inv.write("MANAGEMENT_ADDRESS_TYPE='IPv4'\n")
+        # On install, default to IPv4 unless we have only got an IPv6 admin interface
+        if ((not admin_config.mode) and admin_config.modev6):
+            inv.write("MANAGEMENT_ADDRESS_TYPE='IPv6'\n")
+        else:
+            inv.write("MANAGEMENT_ADDRESS_TYPE='IPv4'\n")
     if constants.CC_PREPARATIONS and install_type == constants.INSTALL_TYPE_FRESH:
         inv.write("CC_PREPARATIONS='true'\n")
     inv.close()

--- a/backend.py
+++ b/backend.py
@@ -169,7 +169,7 @@ def getPrepSequence(ans, interactive):
 
 def getMainRepoSequence(ans, repos):
     seq = []
-    seq.append(Task(repository.installFromRepos, lambda a: [repos] + [a.get('mounts'), a.get('kernel-alt')], [],
+    seq.append(Task(repository.installFromRepos, lambda a: [repos] + [a.get('mounts'), a.get('kernel-alt'), a.get('linstor-version')], [],
                 progress_scale=100,
                 pass_progress_callback=True,
                 progress_text="Installing %s..." % (", ".join([repo.name() for repo in repos]))))

--- a/backend.py
+++ b/backend.py
@@ -844,7 +844,7 @@ def setActiveDiskPartition(disk, boot_partnum, primary_partnum):
 
 def getSRPhysDevs(primary_disk, storage_partnum, guest_disks):
     def sr_partition(disk):
-        if disk == primary_disk:
+        if disk == primary_disk or disk == '/dev/md127':
             return partitionDevice(disk, storage_partnum)
         else:
             return disk

--- a/backend.py
+++ b/backend.py
@@ -35,6 +35,7 @@ from xcp.version import Version
 import version
 from version import *
 from constants import *
+from diskutil import getRemovableDeviceList
 
 MY_PRODUCT_BRAND = PRODUCT_BRAND or PLATFORM_NAME
 
@@ -467,6 +468,16 @@ def performInstallation(answers, ui_package, interactive):
     for r in main_repositories + update_repositories:
         if r.accessor().canEject():
             r.accessor().eject()
+
+    # XCP-ng: so, very unfortunately we don't remember with precision why this was added and
+    # no commit message or comment can help us here.
+    # It may be related to the fact that the "all_repositories" above doesn't contain
+    # the installation CD-ROM or USB stick in the case of a netinstall.
+    # Question: why it is needed at all since there's no repository on the netinstall
+    # installation media?
+    if answers.get('netinstall'):
+        for device in getRemovableDeviceList():
+            util.runCmd2(['eject', device])
 
     if interactive and (constants.HAS_SUPPLEMENTAL_PACKS or
                         "driver-repos" in answers):

--- a/backend.py
+++ b/backend.py
@@ -423,9 +423,17 @@ def performInstallation(answers, ui_package, interactive):
         assert answers['net-admin-interface'].startswith("eth")
         answers['net-admin-bridge'] = "xenbr%s" % answers['net-admin-interface'][3:]
 
+    # A list needs to be used rather than a set since the order of updates is
+    # important.  However, since the same repository might exist in multiple
+    # locations or the same location might be listed multiple times, care is
+    # needed to ensure that there are no duplicates.
+    main_repositories = []
+    update_repositories = []
+    answers_pristine = answers.copy()
+    determineRepositories(answers, answers_pristine, main_repositories, update_repositories)
+
     # perform installation:
     prep_seq = getPrepSequence(answers, interactive)
-    answers_pristine = answers.copy()
     executeSequence(prep_seq, "Preparing for installation...", answers, ui_package, False)
 
     # install from main repositories:
@@ -438,14 +446,6 @@ def performInstallation(answers, ui_package, interactive):
         executeSequence(repo_seq, "Reading package information...", ans, ui_package, False)
 
     answers['installed-repos'] = {}
-
-    # A list needs to be used rather than a set since the order of updates is
-    # important.  However, since the same repository might exist in multiple
-    # locations or the same location might be listed multiple times, care is
-    # needed to ensure that there are no duplicates.
-    main_repositories = []
-    update_repositories = []
-    determineRepositories(answers, answers_pristine, main_repositories, update_repositories)
 
     handleMainRepos(main_repositories, answers)
     if update_repositories:

--- a/backend.py
+++ b/backend.py
@@ -168,7 +168,7 @@ def getPrepSequence(ans, interactive):
 
 def getMainRepoSequence(ans, repos):
     seq = []
-    seq.append(Task(repository.installFromRepos, lambda a: [repos] + [a.get('mounts')], [],
+    seq.append(Task(repository.installFromRepos, lambda a: [repos] + [a.get('mounts'), a.get('kernel-alt')], [],
                 progress_scale=100,
                 pass_progress_callback=True,
                 progress_text="Installing %s..." % (", ".join([repo.name() for repo in repos]))))
@@ -211,6 +211,7 @@ def getFinalisationSequence(ans):
         Task(installBootLoader, A(ans, 'mounts', 'primary-disk',
                                   'target-boot-mode', 'disk-label-suffix', 'bootloader-location',
                                   'serial-console', 'boot-serial', 'host-config', 'fcoe-interfaces'), []),
+        Task(postInstallAltKernel, A(ans, 'mounts', 'kernel-alt'), []),
         Task(touchSshAuthorizedKeys, A(ans, 'mounts'), []),
         Task(setRootPassword, A(ans, 'mounts', 'root-password'), [], args_sensitive=True),
         Task(setTimeZone, A(ans, 'mounts', 'timezone'), []),
@@ -1805,6 +1806,30 @@ for repo in base.repos.repos.itervalues():
     finally:
         util.umount("%s/dev" % mounts['root'])
         os.unlink(external_tmp_filepath)
+
+def postInstallAltKernel(mounts, kernel_alt):
+    """ Install our alternate kernel. Must be called after the bootloader installation. """
+    if not kernel_alt:
+        logger.log('kernel-alt not installed')
+        return
+
+    util.bindMount("/proc", "%s/proc" % mounts['root'])
+    util.bindMount("/sys", "%s/sys" % mounts['root'])
+    util.bindMount("/dev", "%s/dev" % mounts['root'])
+
+    try:
+        rc, out = util.runCmd2(['chroot', mounts['root'], 'rpm', '-q', 'kernel-alt', '--qf', '%{version}'],
+                               with_stdout=True)
+        version = out
+        # Generate the initrd as it was disabled during initial installation
+        util.runCmd2(['chroot', mounts['root'], 'dracut', '-f', '/boot/initrd-%s.img' % version, version])
+
+        # Update grub
+        util.runCmd2(['chroot', mounts['root'], '/opt/xensource/bin/updategrub.py', 'add', 'kernel-alt', version])
+    finally:
+        util.umount("%s/dev" % mounts['root'])
+        util.umount("%s/sys" % mounts['root'])
+        util.umount("%s/proc" % mounts['root'])
 
 ################################################################################
 # OTHER HELPERS

--- a/backend.py
+++ b/backend.py
@@ -1594,15 +1594,15 @@ def configureNetworking(mounts, admin_iface, admin_bridge, admin_config, hn_conf
             print("NETMASK='%s'" % admin_config.netmask, file=mc)
             if admin_config.gateway:
                 print("GATEWAY='%s'" % admin_config.gateway, file=mc)
-            if manual_nameservers:
-                print("DNS='%s'" % (','.join(nameservers),), file=mc)
-            if domain:
-                print("DOMAIN='%s'" % domain, file=mc)
         print("MODEV6='%s'" % netinterface.NetInterface.getModeStr(admin_config.modev6), file=mc)
         if admin_config.modev6 == netinterface.NetInterface.Static:
             print("IPv6='%s'" % admin_config.ipv6addr, file=mc)
             if admin_config.ipv6_gateway:
                 print("IPv6_GATEWAY='%s'" % admin_config.ipv6_gateway, file=mc)
+        if manual_nameservers:
+            print("DNS='%s'" % (','.join(nameservers),), file=mc)
+        if domain:
+            print("DOMAIN='%s'" % domain, file=mc)
         if admin_config.vlan:
             print("VLAN='%d'" % admin_config.vlan, file=mc)
         mc.close()

--- a/backend.py
+++ b/backend.py
@@ -342,6 +342,10 @@ def determineRepositories(answers, answers_pristine, main_repositories, update_r
         for i in answers_pristine['sources']:
             repos = repository.repositoriesFromDefinition(i['media'], i['address'])
             add_repos(main_repositories, update_repositories, repos)
+            repo_gpgcheck = answers.get('repo-gpgcheck', True)
+            for repo in repos:
+                if repo in main_repositories:
+                    repo.setRepoGpgCheck(repo_gpgcheck)
 
     # A single source coming from an interactive install
     if 'source-media' in answers_pristine and 'source-address' in answers_pristine:

--- a/backend.py
+++ b/backend.py
@@ -457,7 +457,8 @@ def performInstallation(answers, ui_package, interactive):
         if r.accessor().canEject():
             r.accessor().eject()
 
-    if interactive and constants.HAS_SUPPLEMENTAL_PACKS:
+    if interactive and (constants.HAS_SUPPLEMENTAL_PACKS or
+                        "driver-repos" in answers):
         # Add supp packs in a loop
         while True:
             media_ans = dict(answers_pristine)

--- a/backend.py
+++ b/backend.py
@@ -444,6 +444,21 @@ def performInstallation(answers, ui_package, interactive):
     answers_pristine = answers.copy()
     determineRepositories(answers, answers_pristine, main_repositories, update_repositories)
 
+    # if upgrading a host with LINSTOR, check we can upgrade it first
+    if answers['install-type'] == INSTALL_TYPE_REINSTALL and answers['linstor-version']:
+        available_linstor_versions = repository.listPackagesFromRepos(
+            main_repositories, 'linstor-satellite', '%{evr}')
+        if not available_linstor_versions:
+            raise RuntimeError("Cannot upgrade host with LINSTOR using an installation source "
+                               "that does not have LINSTOR.  Please use an installation medium "
+                               "which supports upgrading LINSTOR.")
+        if answers['linstor-version'] not in available_linstor_versions:
+            raise RuntimeError("Cannot upgrade host with LINSTOR %s, "
+                               "upgrade repository has versions: %s.  "
+                               "Please make sure your pool is uptodate and use the "
+                               "latest dedicated ISO." %
+                               (answers['linstor-version'], ', '.join(available_linstor_versions)))
+
     # perform installation:
     prep_seq = getPrepSequence(answers, interactive)
     executeSequence(prep_seq, "Preparing for installation...", answers, ui_package, False)

--- a/backend.py
+++ b/backend.py
@@ -1645,12 +1645,18 @@ def configureNetworking(mounts, admin_iface, admin_bridge, admin_config, hn_conf
     # now we need to write /etc/sysconfig/network
     nfd = open("%s/etc/sysconfig/network" % mounts["root"], "w")
     nfd.write("NETWORKING=yes\n")
-    if admin_config.modev6:
+    ipv6 = admin_config.modev6 is not None
+    if ipv6:
         nfd.write("NETWORKING_IPV6=yes\n")
         util.runCmd2(['chroot', mounts['root'], 'systemctl', 'enable', 'ip6tables'])
     else:
         nfd.write("NETWORKING_IPV6=no\n")
         netutil.disable_ipv6_module(mounts["root"])
+
+    with open("%s/etc/sysctl.d/91-net-ipv6.conf" % mounts["root"], "w") as ipv6_conf:
+        for i in ['all', 'default']:
+            ipv6_conf.write('net.ipv6.conf.%s.disable_ipv6=%d\n' % (i, int(not ipv6)))
+
     nfd.write("IPV6_AUTOCONF=no\n")
     nfd.write('NTPSERVERARGS="iburst prefer"\n')
     nfd.close()

--- a/backend.py
+++ b/backend.py
@@ -343,9 +343,11 @@ def determineRepositories(answers, answers_pristine, main_repositories, update_r
             repos = repository.repositoriesFromDefinition(i['media'], i['address'])
             add_repos(main_repositories, update_repositories, repos)
             repo_gpgcheck = answers.get('repo-gpgcheck', True)
+            gpgcheck = answers.get('gpgcheck', True)
             for repo in repos:
                 if repo in main_repositories:
                     repo.setRepoGpgCheck(repo_gpgcheck)
+                    repo.setGpgCheck(gpgcheck)
 
     # A single source coming from an interactive install
     if 'source-media' in answers_pristine and 'source-address' in answers_pristine:

--- a/backend.py
+++ b/backend.py
@@ -318,6 +318,42 @@ def executeSequence(sequence, seq_name, answers, ui, cleanup):
             doCleanup(answers['cleanup'])
             del answers['cleanup']
 
+def determineRepositories(answers, answers_pristine, main_repositories, update_repositories):
+    def add_repos(main_repositories, update_repositories, repos):
+        """Add repositories to the appropriate list, ensuring no duplicates,
+        that the main repository is at the beginning, and that the order of the
+        rest is maintained."""
+
+        for repo in repos:
+            if isinstance(repo, repository.UpdateYumRepository):
+                repo_list = update_repositories
+            else:
+                repo_list = main_repositories
+
+            if repo not in repo_list:
+                if repo.identifier() == MAIN_REPOSITORY_NAME:
+                    repo_list.insert(0, repo)
+                else:
+                    repo_list.append(repo)
+
+    # A list of sources coming from the answerfile
+    if 'sources' in answers_pristine:
+        for i in answers_pristine['sources']:
+            repos = repository.repositoriesFromDefinition(i['media'], i['address'])
+            add_repos(main_repositories, update_repositories, repos)
+
+    # A single source coming from an interactive install
+    if 'source-media' in answers_pristine and 'source-address' in answers_pristine:
+        repos = repository.repositoriesFromDefinition(answers_pristine['source-media'], answers_pristine['source-address'])
+        add_repos(main_repositories, update_repositories, repos)
+
+    for media, address in answers_pristine['extra-repos']:
+        repos = repository.repositoriesFromDefinition(media, address)
+        add_repos(main_repositories, update_repositories, repos)
+
+    if not main_repositories or main_repositories[0].identifier() != MAIN_REPOSITORY_NAME:
+        raise RuntimeError("No main repository found")
+
 def performInstallation(answers, ui_package, interactive):
     logger.log("INPUT ANSWERS DICTIONARY:")
     prettyLogAnswers(answers)
@@ -409,41 +445,7 @@ def performInstallation(answers, ui_package, interactive):
     # needed to ensure that there are no duplicates.
     main_repositories = []
     update_repositories = []
-
-    def add_repos(main_repositories, update_repositories, repos):
-        """Add repositories to the appropriate list, ensuring no duplicates,
-        that the main repository is at the beginning, and that the order of the
-        rest is maintained."""
-
-        for repo in repos:
-            if isinstance(repo, repository.UpdateYumRepository):
-                repo_list = update_repositories
-            else:
-                repo_list = main_repositories
-
-            if repo not in repo_list:
-                if repo.identifier() == MAIN_REPOSITORY_NAME:
-                    repo_list.insert(0, repo)
-                else:
-                    repo_list.append(repo)
-
-    # A list of sources coming from the answerfile
-    if 'sources' in answers_pristine:
-        for i in answers_pristine['sources']:
-            repos = repository.repositoriesFromDefinition(i['media'], i['address'])
-            add_repos(main_repositories, update_repositories, repos)
-
-    # A single source coming from an interactive install
-    if 'source-media' in answers_pristine and 'source-address' in answers_pristine:
-        repos = repository.repositoriesFromDefinition(answers_pristine['source-media'], answers_pristine['source-address'])
-        add_repos(main_repositories, update_repositories, repos)
-
-    for media, address in answers_pristine['extra-repos']:
-        repos = repository.repositoriesFromDefinition(media, address)
-        add_repos(main_repositories, update_repositories, repos)
-
-    if not main_repositories or main_repositories[0].identifier() != MAIN_REPOSITORY_NAME:
-        raise RuntimeError("No main repository found")
+    determineRepositories(answers, answers_pristine, main_repositories, update_repositories)
 
     handleMainRepos(main_repositories, answers)
     if update_repositories:

--- a/backend.py
+++ b/backend.py
@@ -342,8 +342,10 @@ def determineRepositories(answers, answers_pristine, main_repositories, update_r
         for i in answers_pristine['sources']:
             repos = repository.repositoriesFromDefinition(i['media'], i['address'])
             add_repos(main_repositories, update_repositories, repos)
-            repo_gpgcheck = answers.get('repo-gpgcheck', True)
-            gpgcheck = answers.get('gpgcheck', True)
+            repo_gpgcheck = (answers.get('repo-gpgcheck', True) if i['repo_gpgcheck'] is None
+                             else i['repo_gpgcheck'])
+            gpgcheck = (answers.get('gpgcheck', True) if i['gpgcheck'] is None
+                        else i['gpgcheck'])
             for repo in repos:
                 if repo in main_repositories:
                     repo.setRepoGpgCheck(repo_gpgcheck)

--- a/backend.py
+++ b/backend.py
@@ -116,6 +116,8 @@ def getPrepSequence(ans, interactive):
 
         if ans['swraid']:
             seq.append(Task(setupSWRAIDDevice, A(ans, 'disk-label-suffix', 'physical-disks', 'guest-disks'), ['primary-disk', 'guest-disks']))
+        else:
+            seq.append(Task(stopBlockingSWRAIDDevices, A(ans, 'physical-disks'), []))
 
     seq += [
         Task(partitionTargetDisk, A(ans, 'primary-disk', 'installation-to-overwrite', 'preserve-first-partition','sr-on-primary', 'target-platform'),
@@ -553,6 +555,11 @@ def configureNTP(mounts, ntp_config_method, ntp_servers):
     else:
         rewriteNTPConf(mounts['root'], [])
 
+# Stop any multi-devices using the physical disks we require
+def stopBlockingSWRAIDDevices(physical_disks):
+    for device in getMdDevicesUsing(physical_disks):
+        diskutil.stopSWRAID(device)
+
 # Setup a new SW RAID device using mdadm
 # The primary-disk (/dev/md/*) is built from the physical disks provided in the answerfile
 def setupSWRAIDDevice(disk_label_suffix, physical_disks, guest_disks):
@@ -563,8 +570,7 @@ def setupSWRAIDDevice(disk_label_suffix, physical_disks, guest_disks):
         diskutil.stopSWRAID(primary_disk)
 
     # Stop any multi-devices using the physical disks we require
-    for device in getMdDevicesUsing(physical_disks):
-        diskutil.stopSWRAID(device)
+    stopBlockingSWRAIDDevices(physical_disks)
 
     # Zero any superblocks on the physical disks
     for disk in physical_disks:

--- a/backend.py
+++ b/backend.py
@@ -190,6 +190,7 @@ def getRepoSequence(ans, repos):
 
 def getFinalisationSequence(ans):
     seq = [
+        Task(importYumAndRpmGpgKeys, A(ans, 'mounts'), []),
         Task(writeResolvConf, A(ans, 'mounts', 'manual-hostname', 'manual-nameservers'), []),
         Task(writeMachineID, A(ans, 'mounts'), []),
         Task(writeKeyboardConfiguration, A(ans, 'mounts', 'keymap'), []),
@@ -1777,6 +1778,33 @@ def isSWRAIDSyncd(primary_disk):
         logger.log("Failed to check if SWRAID device is sync'd due to: " + str(ex))
         return False
 
+def importYumAndRpmGpgKeys(mounts):
+    # Python script that uses yum functions to import the GPG key for our repositories
+    import_yum_keys = """#!/bin/env python
+from __future__ import print_function
+from yum import YumBase
+
+def retTrue(*args, **kwargs):
+    return True
+
+base = YumBase()
+for repo in base.repos.repos.itervalues():
+    if repo.id.startswith('xcp-ng'):
+        print("*** Importing GPG key for repository %s - %s" % (repo.id, repo.name))
+        base.getKeyForRepo(repo, callback=retTrue)
+"""
+    internal_tmp_filepath = '/tmp/import_yum_keys.py'
+    external_tmp_filepath = mounts['root'] + internal_tmp_filepath
+    with open(external_tmp_filepath, 'w') as f:
+        f.write(import_yum_keys)
+    # bind mount /dev, necessary for NSS initialization without which RPM won't work
+    util.bindMount('/dev', "%s/dev" % mounts['root'])
+    try:
+        util.runCmd2(['chroot', mounts['root'], 'python', internal_tmp_filepath])
+        util.runCmd2(['chroot', mounts['root'], 'rpm', '--import', '/etc/pki/rpm-gpg/RPM-GPG-KEY-xcpng'])
+    finally:
+        util.umount("%s/dev" % mounts['root'])
+        os.unlink(external_tmp_filepath)
 
 ################################################################################
 # OTHER HELPERS

--- a/constants.py
+++ b/constants.py
@@ -63,8 +63,7 @@ def error_string(error, logname, with_hd):
     if err[-1:] != '.':
         err += '.'
 
-    return ('An unrecoverable error has occurred.  ' + err +
-        '\n\nPlease refer to your user guide or contact a Technical Support Representative for more details.')
+    return ('An unrecoverable error has occurred.  ' + err)
 
 # minimum hardware specs:
 # memory checks should be done against MIN_SYSTEM_RAM_MB since libxc

--- a/constants.py
+++ b/constants.py
@@ -206,3 +206,6 @@ PARTITIONING_ERROR = \
 # SW RAID
 swraid_query_interval = 10  # seconds
 swraid_speed_write_max = 5000000
+
+# crypto configuration
+MIN_KEY_SIZE = 2048

--- a/diskutil.py
+++ b/diskutil.py
@@ -535,7 +535,11 @@ STORAGE_LVM = 1
 STORAGE_OTHER = 2
 STORAGE_GFS2 = 3
 
-def probeDisk(device):
+RAID_MEMBERS_PROBE_MEMBER = "probe member"
+RAID_MEMBERS_DONT_PROBE = "don't probe"
+RAID_MEMBERS_PROBE_RAID = "probe raid"
+
+def probeDisk(device, raid_members):
     """Examines device and reports the apparent presence of a XenServer installation and/or related usage
     Returns a Disk object with XenServer partitions and state (boot, root, storage, logs, swap)
 
@@ -549,9 +553,22 @@ def probeDisk(device):
         swap is a tuple of True or False and the partition device
     """
 
-    logger.debug("probeDisk(%r)", device)
+    logger.debug("probeDisk(%r, raid_members = %r)", device, raid_members)
+
     disk = Disk(device)
     possible_srs = set()
+
+    # if part of assembled raid, must check raid instead
+    raids = getMdDevicesUsing([device])
+    if raid_members == RAID_MEMBERS_DONT_PROBE and raids:
+        logger.info("%s is part of a raid device, not probing further", device)
+        return disk
+    if len(raids) > 1:
+        raise RuntimeError("Device %s is used by several MD devices (%s), fix this first"
+                           % (devices, ', '.join(raids)))
+    if raid_members == RAID_MEMBERS_PROBE_RAID and raids:
+        logger.info("%s is part of a raid device, probing %s", device, raids[0])
+        return probeDisk(raids[0], raid_members = RAID_MEMBERS_PROBE_RAID)
 
     tool = PartitionTool(device)
     tool.dump()

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -123,6 +123,15 @@ Elements for 'installation' modes
     The location of the installation repository or a Supplemental
     Pack. There may be multiple 'source' elements.
 
+    Optional attributes for <source> only:
+
+      repo-gpgcheck=bool
+      gpgcheck=bool
+
+        Override the global yum gpgcheck setting, respectively for
+        repodata and RPMs, for this source only.  Only applies to
+        repositories that are not Supplemental Packs (none of which
+        are checked).
 
   <bootloader location="mbr|partition">grub2|extlinux[D]|grub[D]</bootloader>?
 

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -34,6 +34,21 @@ Restore:
   ...
 </restore>
 
+
+Common Attributes
+-----------------
+
+  repo-gpgcheck="false"
+
+    Disable check of repodata signature (`repo_gpgcheck=0` in
+    `yum.conf`), for all yum repositories that are not Supplemental
+    Packs (none of which are checked). Don't use this for a network
+    install of a production server, and make sure to verify the
+    authenticity of your install media through other means.
+
+    Validity: any <installation> operation.
+
+
 Elements common to all answerfiles, both 'installation' and 'restore'
 ---------------------------------------------------------------------
 

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -48,6 +48,14 @@ Common Attributes
 
     Validity: any <installation> operation.
 
+  gpgcheck="false"
+
+    Disable check of rpm signature (`gpgcheck=0` in `yum.conf`), for
+    all yum repositories that are not Supplemental Packs (none of
+    which are checked). Don't use this for a production server.
+
+    Validity: any <installation> operation.
+
 
 Elements common to all answerfiles, both 'installation' and 'restore'
 ---------------------------------------------------------------------

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -238,6 +238,19 @@ Format of 'source' and 'driver-source'
         Default: False
 
 
+  <raid device=dev>
+    <disk>dev1</disk>
+    <disk>dev2</disk>
+  </raid>?
+
+    Specifies the target disks and md device for creating a
+    software RAID 1 array. The md device can then be used in
+    <primary-disk> below. (new in xcp-ng 7.5.0-2 and 7.6)
+
+    This is a legacy XCP-ng-specific syntax, using the "swraid"
+    attribute on <primary-disk> is the official way.
+
+
   <guest-disks>
     <guest-disk>dev</guest-disk>*
   </guest-disks>?

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -355,9 +355,13 @@ Format of 'source' and 'driver-source'
 
     Local SR type.
 
-    Default: lvm if the disks included in local SR storage all have 512 byte
+    Default: ext if the disks included in local SR storage all have 512 byte
              logical blocks, otherwise (when available) the SR type from
              the large-block-capable-sr-type feature
+
+    Note that while it reflects the default choice in the text UI,
+    this differs from XenServer and from XCP-ng releases lower than
+    8.3, where the default was "lvm".
 
 
 Upgrade Elements

--- a/doc/features.txt
+++ b/doc/features.txt
@@ -15,6 +15,10 @@ Currently available feature flags are:
     This only impacts the UI, the <source> answerfile construct still
     allows to include supplemental packs without this feature flag.
 
+    This also has no impact if users previously load a driver disk:
+    they will get the opportunity to insert it again to get the driver
+    installed on the host.
+
   large-block-capable-sr-type
 
     Allow the use of an SR type for local storage that (unlike "lvm" and

--- a/doc/parameters.txt
+++ b/doc/parameters.txt
@@ -227,3 +227,8 @@ Installer
   --no-repo-gpgcheck
 
     Disable check of repodata signature, for all yum repositories.
+
+
+  --no-gpgcheck
+
+    Disable check of rpm signature, for all yum repositories.

--- a/doc/parameters.txt
+++ b/doc/parameters.txt
@@ -222,3 +222,8 @@ Installer
   --cc-preparations
 
     Prepare configuration for common criteria security.
+
+
+  --no-repo-gpgcheck
+
+    Disable check of repodata signature, for all yum repositories.

--- a/init
+++ b/init
@@ -94,7 +94,7 @@ def sig_term(x, y):
 def main(args):
     # log to tty3
     logger.openLog('/dev/tty3')
-    logger.openLog('/tmp/install-log')
+    logger.openLog('/tmp/install-log', level=logger.logging.DEBUG)
 
     tty = None
     signal.signal(signal.SIGTERM, sig_term)

--- a/install.py
+++ b/install.py
@@ -130,6 +130,9 @@ def go(ui, args, answerfile_address, answerfile_script):
             results['network-backend'] = constants.NETWORK_BACKEND_BRIDGE
         elif opt == "--mount":
             disktools.DeviceMounter.addMountPoints(val)
+        elif opt == "--no-repo-gpgcheck":
+            results['repo-gpgcheck'] = False
+            logger.log("Yum gpg check of repository disabled on command-line")
 
     if boot_console and not serial_console:
         serial_console = boot_console

--- a/install.py
+++ b/install.py
@@ -140,6 +140,10 @@ def go(ui, args, answerfile_address, answerfile_script):
         elif opt == "--kernel-alt":
             results['kernel-alt'] = True
             logger.log("Using alternate kernel.")
+        # XCP-ng: netinstall
+        elif opt == "--netinstall":
+            results['netinstall'] = True
+            logger.log("This is a netinstall.")
 
     if (('gpgcheck' in results or 'repo-gpgcheck' in results) and
         (answerfile_address or answerfile_script)):

--- a/install.py
+++ b/install.py
@@ -137,6 +137,11 @@ def go(ui, args, answerfile_address, answerfile_script):
             results['gpgcheck'] = False
             logger.log("Yum gpg check of RPMs disabled on command-line")
 
+    if (('gpgcheck' in results or 'repo-gpgcheck' in results) and
+        (answerfile_address or answerfile_script)):
+        raise RuntimeError("Using answerfile, gpgcheck settings on CLI would be ignored.  "
+                           "Set them inside answerfile instead.")
+
     if boot_console and not serial_console:
         serial_console = boot_console
         boot_serial = True

--- a/install.py
+++ b/install.py
@@ -136,6 +136,10 @@ def go(ui, args, answerfile_address, answerfile_script):
         elif opt == "--no-gpgcheck":
             results['gpgcheck'] = False
             logger.log("Yum gpg check of RPMs disabled on command-line")
+        # XCP-ng addition: alternate kernel
+        elif opt == "--kernel-alt":
+            results['kernel-alt'] = True
+            logger.log("Using alternate kernel.")
 
     if (('gpgcheck' in results or 'repo-gpgcheck' in results) and
         (answerfile_address or answerfile_script)):

--- a/install.py
+++ b/install.py
@@ -133,6 +133,9 @@ def go(ui, args, answerfile_address, answerfile_script):
         elif opt == "--no-repo-gpgcheck":
             results['repo-gpgcheck'] = False
             logger.log("Yum gpg check of repository disabled on command-line")
+        elif opt == "--no-gpgcheck":
+            results['gpgcheck'] = False
+            logger.log("Yum gpg check of RPMs disabled on command-line")
 
     if boot_console and not serial_console:
         serial_console = boot_console

--- a/netinterface.py
+++ b/netinterface.py
@@ -16,7 +16,7 @@ def getTextOrNone(nodelist):
             rc = rc + node.data
     return rc == "" and None or rc.strip().encode()
 
-class NetInterface:
+class NetInterface(object):
     """ Represents the configuration of a network interface. """
 
     Static = 1

--- a/netinterface.py
+++ b/netinterface.py
@@ -130,6 +130,10 @@ class NetInterface(object):
         """ Returns true if an IPv6 static interface configuration is represented. """
         return self.modev6 == self.Static
 
+    def isDynamic(self):
+        """ Returns true if a dynamic interface configuration is represented. """
+        return self.mode == self.DHCP or self.modev6 == self.DHCP or self.modev6 == self.Autoconf
+
     def isVlan(self):
         return self.vlan is not None
 

--- a/netinterface.py
+++ b/netinterface.py
@@ -191,14 +191,18 @@ class NetInterface(object):
 
 
     def waitUntilUp(self, iface):
-        if not self.isStatic4():
-            return True
-        if not self.gateway:
-            return True
+        iface_name = self.getInterfaceName(iface)
+        if self.isStatic4() and self.gateway and util.runCmd2(
+            ['/usr/sbin/arping', '-f', '-w', '120', '-I', iface_name, self.gateway]
+        ):
+            return False
 
-        rc = util.runCmd2(['/usr/sbin/arping', '-f', '-w', '120', '-I',
-                           self.getInterfaceName(iface), self.gateway])
-        return rc == 0
+        if self.isStatic6() and self.ipv6_gateway and util.runCmd2(
+            ['/usr/sbin/ndisc6', '-1', '-w', '120', self.ipv6_gateway, iface_name]
+        ):
+            return False
+
+        return True
 
     @staticmethod
     def getModeStr(mode):

--- a/netinterface.py
+++ b/netinterface.py
@@ -185,3 +185,22 @@ class NetInterface(object):
         if mode == NetInterface.Autoconf:
             return 'autoconf'
         return 'none'
+
+class NetInterfaceV6(NetInterface):
+    def __init__(self, mode, hwaddr, ipaddr=None, netmask=None, gateway=None, dns=None, domain=None, vlan=None):
+        super(NetInterfaceV6, self).__init__(None, hwaddr, None, None, None, None, None, vlan)
+
+        ipv6addr = None
+        if mode == self.Static:
+            assert ipaddr
+            assert netmask
+
+            ipv6addr = ipaddr + "/" + netmask
+            if dns == '':
+                dns = None
+            elif isinstance(dns, str):
+                dns = [ dns ]
+            self.dns = dns
+            self.domain = domain
+
+        self.addIPv6(mode, ipv6addr=ipv6addr, ipv6gw=gateway)

--- a/netinterface.py
+++ b/netinterface.py
@@ -145,8 +145,7 @@ class NetInterface(object):
         """ Write a RedHat-style configuration entry for this interface to
         file object f using interface name iface. """
 
-        assert self.modev6 is None
-        assert self.mode
+        assert self.modev6 or self.mode
         iface_vlan = self.getInterfaceName(iface)
 
         f = open('/etc/sysconfig/network-scripts/ifcfg-%s' % iface_vlan, 'w')
@@ -155,7 +154,7 @@ class NetInterface(object):
         if self.mode == self.DHCP:
             f.write("BOOTPROTO=dhcp\n")
             f.write("PERSISTENT_DHCLIENT=1\n")
-        else:
+        elif self.mode == self.Static:
             # CA-11825: broadcast needs to be determined for non-standard networks
             bcast = self.getBroadcast()
             f.write("BOOTPROTO=none\n")
@@ -165,6 +164,27 @@ class NetInterface(object):
             f.write("NETMASK=%s\n" % self.netmask)
             if self.gateway:
                 f.write("GATEWAY=%s\n" % self.gateway)
+
+        if self.modev6:
+            with open('/etc/sysconfig/network', 'w') as net_conf:
+                net_conf.write("NETWORKING_IPV6=yes\n")
+            f.write("IPV6INIT=yes\n")
+            f.write("IPV6_DEFROUTE=yes\n")
+            f.write("IPV6_DEFAULTDEV=%s\n" % iface_vlan)
+
+        if self.modev6 == self.DHCP:
+            f.write("DHCPV6C=yes\n")
+            f.write("PERSISTENT_DHCLIENT_IPV6=yes\n")
+            f.write("IPV6_FORCE_ACCEPT_RA=yes\n")
+            f.write("IPV6_AUTOCONF=no\n")
+        elif self.modev6 == self.Static:
+            f.write("IPV6ADDR=%s\n" % self.ipv6addr)
+            if self.ipv6_gateway:
+                f.write("IPV6_DEFAULTGW=%s\n" % (self.ipv6_gateway))
+            f.write("IPV6_AUTOCONF=no\n")
+        elif self.modev6 == self.Autoconf:
+            f.write("IPV6_AUTOCONF=yes\n")
+
         if self.vlan:
             f.write("VLAN=yes\n")
         f.close()

--- a/netinterface.py
+++ b/netinterface.py
@@ -122,9 +122,13 @@ class NetInterface(object):
             return False
         return self.mode or self.modev6
 
-    def isStatic(self):
-        """ Returns true if a static interface configuration is represented. """
+    def isStatic4(self):
+        """ Returns true if an IPv4 static interface configuration is represented. """
         return self.mode == self.Static
+
+    def isStatic6(self):
+        """ Returns true if an IPv6 static interface configuration is represented. """
+        return self.modev6 == self.Static
 
     def isVlan(self):
         return self.vlan is not None
@@ -167,7 +171,7 @@ class NetInterface(object):
 
 
     def waitUntilUp(self, iface):
-        if not self.isStatic():
+        if not self.isStatic4():
             return True
         if not self.gateway:
             return True

--- a/netutil.py
+++ b/netutil.py
@@ -4,12 +4,12 @@ import os
 import diskutil
 import util
 import re
+import socket
 import subprocess
 import time
 import errno
 from xcp import logger
 from xcp.net.biosdevname import all_devices_all_names
-from socket import inet_ntoa
 from struct import pack
 
 class NIC:
@@ -206,16 +206,21 @@ def valid_vlan(vlan):
         return False
     return True
 
+def valid_ip_address_family(addr, family):
+    try:
+        socket.inet_pton(family, addr)
+        return True
+    except socket.error:
+        return False
+
+def valid_ipv4_addr(addr):
+    return valid_ip_address_family(addr, socket.AF_INET)
+
+def valid_ipv6_addr(addr):
+    return valid_ip_address_family(addr, socket.AF_INET6)
+
 def valid_ip_addr(addr):
-    if not re.match('^\d+\.\d+\.\d+\.\d+$', addr):
-        return False
-    els = addr.split('.')
-    if len(els) != 4:
-        return False
-    for el in els:
-        if int(el) > 255:
-            return False
-    return True
+    return valid_ipv4_addr(addr) or valid_ipv6_addr(addr)
 
 def network(ipaddr, netmask):
     ip = list(map(int,ipaddr.split('.',3)))
@@ -227,7 +232,7 @@ def prefix2netmask(mask):
     bits = 0
     for i in range(32-mask, 32):
         bits |= (1 << i)
-    return inet_ntoa(pack('>I', bits))
+    return socket.inet_ntoa(pack('>I', bits))
 
 class NetDevices:
     def __init__(self):

--- a/netutil.py
+++ b/netutil.py
@@ -73,7 +73,7 @@ def writeResolverFile(configuration, filename):
 
     for iface in configuration:
         settings = configuration[iface]
-        if settings.isStatic() and settings.dns:
+        if settings.isStatic4() and settings.dns:
             if settings.dns:
                 for server in settings.dns:
                     outfile.write("nameserver %s\n" % server)

--- a/netutil.py
+++ b/netutil.py
@@ -118,7 +118,11 @@ def interfaceUp(interface):
     if rc != 0:
         return False
     inets = [x for x in out.split("\n") if x.startswith("    inet ")]
-    return len(inets) == 1
+    if len(inets) == 1:
+        return True
+
+    inet6s = [x for x in out.split("\n") if x.startswith("    inet6 ")]
+    return len(inet6s) > 1  # Not just the fe80:: address
 
 # work out if a link is up:
 def linkUp(interface):

--- a/netutil.py
+++ b/netutil.py
@@ -73,7 +73,7 @@ def writeResolverFile(configuration, filename):
 
     for iface in configuration:
         settings = configuration[iface]
-        if settings.isStatic4() and settings.dns:
+        if (not settings.isDynamic()) and settings.dns:
             if settings.dns:
                 for server in settings.dns:
                     outfile.write("nameserver %s\n" % server)

--- a/product.py
+++ b/product.py
@@ -28,6 +28,18 @@ THIS_PLATFORM_VERSION = Version.from_string(version.PLATFORM_VERSION)
 XENSERVER_7_0_0 = Version([2, 1, 0]) # Platform version
 XENSERVER_MIN_VERSION = XENSERVER_7_0_0
 
+def is_rootfs_uefi(mount_point):
+    try:
+        with open(os.path.join(mount_point, 'etc', 'fstab'), 'r') as fstab:
+            for line in fstab:
+                m = re.search(r'^\s*[^#]+\s/boot/efi\s', line)
+                if m:
+                    return True
+    except FileNotFoundError:
+        pass
+
+    return False
+
 class ExistingInstallation:
     def __init__(self, primary_disk, boot_device, state_device):
         self.primary_disk = primary_disk

--- a/product.py
+++ b/product.py
@@ -604,7 +604,7 @@ def findXenSourceProducts():
     for disk_device in diskutil.getQualifiedDiskList():
         inst = None
         try:
-            disk = diskutil.probeDisk(disk_device)
+            disk = diskutil.probeDisk(disk_device, raid_members = diskutil.RAID_MEMBERS_DONT_PROBE)
             if disk.root[0] == diskutil.INSTALL_RETAIL:
                 inst = ExistingRetailInstallation(disk_device, disk.boot[1], disk.root[1], disk.state[1], disk.storage)
         except Exception as e:

--- a/product.py
+++ b/product.py
@@ -40,6 +40,14 @@ def is_rootfs_uefi(mount_point):
 
     return False
 
+def getLinstorVersion(rootfs_mount):
+    """ Returns the package version of the LINSTOR packages if any """
+    command = ['rpm', '--root', rootfs_mount, '-q', '--qf', '%{evr}', 'linstor-satellite']
+    rc, out = util.runCmd2(command, with_stdout=True)
+    if rc != 0:
+        return None
+    return out
+
 class ExistingInstallation:
     def __init__(self, primary_disk, boot_device, state_device):
         self.primary_disk = primary_disk
@@ -377,6 +385,9 @@ class ExistingInstallation:
                 pc.close()
             except:
                 pass
+
+            results['linstor-version'] = getLinstorVersion(self.state_fs.mount_point) or None
+            logger.info("LINSTOR version detected: %s" % (results['linstor-version'],))
 
         finally:
             self.unmount_state()

--- a/product.py
+++ b/product.py
@@ -575,6 +575,10 @@ def findXenSourceBackups():
                 logger.log("findXenSourceBackups: ignoring later platform: %s > %s" %
                            (backup.version, THIS_PLATFORM_VERSION))
                 raise StopIteration()
+            if not os.path.exists(backup.root_disk):
+                logger.error("findXenSourceBackups: PRIMARY_DISK=%r does not exist" %
+                             (backup.root_disk,))
+                raise StopIteration()
 
             backups.append(backup)
 

--- a/product.py
+++ b/product.py
@@ -561,12 +561,25 @@ def findXenSourceBackups():
         b = None
         try:
             b = util.TempMount(p, 'backup-', ['ro'], 'ext3')
-            if os.path.exists(os.path.join(b.mount_point, '.xen-backup-partition')):
-                backup = XenServerBackup(p, b.mount_point)
-                logger.log("Found a backup: %s" % (repr(backup),))
-                if backup.version >= XENSERVER_MIN_VERSION and \
-                        backup.version <= THIS_PLATFORM_VERSION:
-                    backups.append(backup)
+            if not os.path.exists(os.path.join(b.mount_point, '.xen-backup-partition')):
+                raise StopIteration()
+
+            backup = XenServerBackup(p, b.mount_point)
+            logger.log("Found a backup: %s" % (repr(backup),))
+
+            if backup.version < XENSERVER_MIN_VERSION:
+                logger.log("findXenSourceBackups: ignoring, platform too old: %s < %s" %
+                           (backup.version, XENSERVER_MIN_VERSION))
+                raise StopIteration()
+            if backup.version > THIS_PLATFORM_VERSION:
+                logger.log("findXenSourceBackups: ignoring later platform: %s > %s" %
+                           (backup.version, THIS_PLATFORM_VERSION))
+                raise StopIteration()
+
+            backups.append(backup)
+
+        except StopIteration:
+            pass
         except Exception as ex:
             logger.info("findXenSourceBackups caught exception for partition %s", p, exc_info=1)
             pass

--- a/product.py
+++ b/product.py
@@ -567,7 +567,8 @@ def findXenSourceBackups():
                 if backup.version >= XENSERVER_MIN_VERSION and \
                         backup.version <= THIS_PLATFORM_VERSION:
                     backups.append(backup)
-        except:
+        except Exception as ex:
+            logger.info("findXenSourceBackups caught exception for partition %s", p, exc_info=1)
             pass
         if b:
             b.unmount()

--- a/product.py
+++ b/product.py
@@ -75,6 +75,15 @@ class ExistingInstallation:
         self.mount_state()
         result = True
         try:
+            # Don't propose to upgrade a BIOS installation with a UEFI installer and conversely
+            existing_is_uefi = is_rootfs_uefi(self.join_state_path())
+            if existing_is_uefi != constants.UEFI_INSTALLER:
+                    logger.log("Cannot upgrade %s, installer mode (%s) does not match existing boot mode (%s)" %
+                                (self.primary_disk,
+                                "uefi" if constants.UEFI_INSTALLER else "legacy BIOS",
+                                "uefi" if existing_is_uefi else "legacy BIOS"))
+                    return False
+
             # CA-38459: handle missing firstboot directory e.g. Rio
             if os.path.exists(self.join_state_path('etc/firstboot.d/state')):
                 firstboot_files = [ f for f in os.listdir(self.join_state_path('etc/firstboot.d')) \

--- a/product.py
+++ b/product.py
@@ -579,6 +579,13 @@ def findXenSourceBackups():
             backup = XenServerBackup(p, b.mount_point)
             logger.log("Found a backup: %s" % (repr(backup),))
 
+            # Don't restore a BIOS backup with a UEFI installer and conversely
+            backup_is_uefi = is_rootfs_uefi(b.mount_point)
+            if backup_is_uefi != constants.UEFI_INSTALLER:
+                logger.log("findXenSourceBackups: ignoring, installer mode (%s) does not match backup boot mode (%s)" %
+                           ("uefi" if constants.UEFI_INSTALLER else "legacy BIOS", "uefi" if backup_is_uefi else "legacy BIOS" ))
+                raise StopIteration()
+
             if backup.version < XENSERVER_MIN_VERSION:
                 logger.log("findXenSourceBackups: ignoring, platform too old: %s < %s" %
                            (backup.version, XENSERVER_MIN_VERSION))

--- a/report.py
+++ b/report.py
@@ -68,7 +68,7 @@ def disk_more_info(context):
     if not context: return True
 
     usage = 'unknown'
-    disk = diskutil.probeDisk(context)
+    disk = diskutil.probeDisk(context, raid_members = diskutil.RAID_MEMBERS_DONT_PROBE)
     if disk.root[0]:
         usage = "%s installation" % (PRODUCT_BRAND or PLATFORM_NAME)
     elif disk.storage[0]:
@@ -93,7 +93,7 @@ def get_local_disk(answers):
         (vendor, model, size) = diskutil.getExtendedDiskInfo(de)
         # determine current usage
         target_is_sr[de] = False
-        disk = diskutil.probeDisk(de)
+        disk = diskutil.probeDisk(de, raid_members = diskutil.RAID_MEMBERS_DONT_PROBE)
         if disk.storage[0]:
             target_is_sr[de] = True
         (vendor, model, size) = diskutil.getExtendedDiskInfo(de)

--- a/repository.py
+++ b/repository.py
@@ -830,15 +830,43 @@ def installFromYum(targets, mounts, progress_callback, cachedir):
         rv = p.wait()
         stderr.seek(0)
         stderr = stderr.read()
+        gpg_error_message = None
         if stderr:
             logger.log("YUM stderr: %s" % stderr.strip())
+
+            if ' in import_key_to_pubring' in stderr:
+                gpg_error_message = "Signature key import failed"
+            # add any other instance of uncaught GpgmeError before this like
+            elif 'gpgme.GpgmeError: ' in stderr:
+                gpg_error_message = "Cryptography-related yum crash"
+
+            elif re.search("Couldn't open file [^ ]*/repodata/repomd.xml.asc", stderr):
+                # would otherwise be mistaken for "pubring import" !?
+                gpg_error_message = "No signature on repository metadata"
+            elif 'repomd.xml signature could not be verified' in stderr:
+                gpg_error_message = "Repository signature verification failure"
+
+            else:
+                match = re.search("Public key for ([^ ]*.rpm) is not installed", stderr)
+                if match:
+                    gpg_error_message = "Missing key for %s" % (match.group(1),)
+                match = re.search("Package ([^ ]*.rpm) is not signed", stderr)
+                if match:
+                    gpg_error_message = "Package not signed: %s" % (match.group(1),)
+                match = re.search(r" ([^ ]*): \[Errno [0-9]*\] No more mirrors to try", stderr)
+                if match:
+                    # rpm not found or corrupted/re-signed/etc
+                    gpg_error_rpm_not_found = match.group(1)
+                    gpg_error_message = "Cannot find valid rpm for %s" % (match.group(1),)
 
         if rv:
             if rv > 0:
                 logger.log("Yum exited with %d" % rv)
             else:
                 logger.log("Yum killed by signal %d" % -rv)
-            raise ErrorInstallingPackage("Error installing packages")
+            if gpg_error_message is None:
+                gpg_error_message = "Error installing packages"
+            raise ErrorInstallingPackage(gpg_error_message)
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))
 

--- a/repository.py
+++ b/repository.py
@@ -881,6 +881,26 @@ def installFromYum(yum_conf_path, targets, mounts, progress_callback, cachedir):
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))
 
+def createMainYumConfig(yum_conf_path, repos, cachedir):
+    with open(yum_conf_path, 'w') as yum_conf:
+        yum_conf.write(_generateYumConf(cachedir))
+        for repo in repos:
+            url = repo._accessor.url()
+            yum_conf.write("""
+[%s]
+name=%s
+baseurl=%s
+""" % (repo.identifier(), repo.identifier(), url.getPlainURL()))
+            username = url.getUsername()
+            if username is not None:
+                yum_conf.write("username=%s\n" % (url.getUsername(),))
+            password = url.getPassword()
+            if password is not None:
+                yum_conf.write("password=%s\n" % (url.getPassword(),))
+            repo_config = repo._repo_config()
+            if repo_config is not None:
+                yum_conf.write(repo_config)
+
 def installFromRepos(progress_callback, repos, mounts, kernel_alt, linstor_version):
     """Install from a stacked set of repositories"""
 
@@ -892,26 +912,7 @@ def installFromRepos(progress_callback, repos, mounts, kernel_alt, linstor_versi
         repo._accessor.start()
 
     try:
-        # Build a yum config
-        with open(yum_conf_path, 'w') as yum_conf:
-            yum_conf.write(_generateYumConf(cachedir))
-            for repo in repos:
-                url = repo._accessor.url()
-                yum_conf.write("""
-[%s]
-name=%s
-baseurl=%s
-""" % (repo.identifier(), repo.identifier(), url.getPlainURL()))
-                username = url.getUsername()
-                if username is not None:
-                    yum_conf.write("username=%s\n" % (url.getUsername(),))
-                password = url.getPassword()
-                if password is not None:
-                    yum_conf.write("password=%s\n" % (url.getPassword(),))
-                repo_config = repo._repo_config()
-                if repo_config is not None:
-                    yum_conf.write(repo_config)
-
+        createMainYumConfig(yum_conf_path, repos, cachedir)
 
         repos[0].disableInitrdCreation(mounts['root'])
         targets = []

--- a/repository.py
+++ b/repository.py
@@ -246,6 +246,7 @@ class MainYumRepository(YumRepositoryWithInfo):
         self._identifier = MAIN_REPOSITORY_NAME
         self.keyfiles = []
         self._repo_gpg_check = True
+        self._gpg_check = True
 
         def get_name_version(config_parser, section, name_key, vesion_key):
             name, version = None, None
@@ -316,10 +317,10 @@ class MainYumRepository(YumRepositoryWithInfo):
                 outfh = open(key_path, "w")
                 outfh.write(infh.read())
                 return """
-gpgcheck=1
+gpgcheck=%s
 repo_gpgcheck=%s
 gpgkey=file://%s
-""" % (int(self._repo_gpg_check), key_path)
+""" % (int(self._gpg_check), int(self._repo_gpg_check), key_path)
             finally:
                 if infh:
                     infh.close()
@@ -358,6 +359,10 @@ gpgkey=file://%s
     def setRepoGpgCheck(self, value):
         logger.log("%s: setRepoGpgCheck(%s)" % (self, value))
         self._repo_gpg_check = value
+
+    def setGpgCheck(self, value):
+        logger.log("%s: setGpgCheck(%s)" % (self, value))
+        self._gpg_check = value
 
 class UpdateYumRepository(YumRepositoryWithInfo):
     """Represents a Yum repository containing packages and associated meta data for an update."""

--- a/repository.py
+++ b/repository.py
@@ -188,7 +188,7 @@ class YumRepository(Repository):
         assert self._targets is not None
         url = self._accessor.url()
         logger.log("URL: " + str(url))
-        yum_conf_path = '/root/yum.conf'
+        yum_conf_path = '/root/yum-%s.conf' % (self._identifier,)
         with open(yum_conf_path, 'w') as yum_conf:
             yum_conf.write(self._yum_conf)
             yum_conf.write("""
@@ -429,7 +429,7 @@ history_record=false
     def isRepo(cls, accessor):
         if UpdateYumRepository.isRepo(accessor):
             url = accessor.url()
-            yum_conf_path = '/root/yum.conf'
+            yum_conf_path = '/root/yum-driverrepo.conf'
             with open(yum_conf_path, 'w') as yum_conf:
                 yum_conf.write(cls._yum_conf)
                 yum_conf.write("""

--- a/repository.py
+++ b/repository.py
@@ -933,3 +933,30 @@ def installFromRepos(progress_callback, repos, mounts, kernel_alt, linstor_versi
     finally:
         for repo in repos:
             repo._accessor.finish()
+
+# unlike modern dnf, silly yum in el7 does not hide "0:" in "%{evr}"
+NULL_EPOCH_RE = re.compile(r"(.*)\b0:(.*)$")
+def hideNullEpoch(package):
+    m = re.match(NULL_EPOCH_RE, package)
+    if not m:
+        return package
+    return "".join(m.groups())
+
+def listPackagesFromRepos(repos, rpm_pattern, query_format='%{nevr}'):
+    cachedir = "var/cache/yum/installer"
+    yum_conf_path = '/root/yum-repoquery.conf'
+
+    for repo in repos:
+        repo._accessor.start()
+
+    try:
+        createMainYumConfig(yum_conf_path, repos, cachedir)
+
+        rv, out = util.runCmd2(['repoquery', '-c', yum_conf_path,
+                                '--qf', query_format,
+                                rpm_pattern], with_stdout=True)
+    finally:
+        for repo in repos:
+            repo._accessor.finish()
+
+    return [hideNullEpoch(package) for package in out.split()]

--- a/repository.py
+++ b/repository.py
@@ -879,7 +879,7 @@ def installFromYum(targets, mounts, progress_callback, cachedir):
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))
 
-def installFromRepos(progress_callback, repos, mounts, kernel_alt):
+def installFromRepos(progress_callback, repos, mounts, kernel_alt, linstor_version):
     """Install from a stacked set of repositories"""
 
     logger.log("installFromRepos, kernel_alt=%s" % (kernel_alt,))
@@ -917,6 +917,11 @@ baseurl=%s
         targets = list(set(targets))
         if kernel_alt:
             targets.append('kernel-alt')
+        if linstor_version:
+            targets.extend(['xcp-ng-release-linstor', 'xcp-ng-linstor',
+                            'linstor-satellite-%s' % linstor_version,
+                            'linstor-controller-%s' % linstor_version,
+                            ])
 
         installFromYum(targets, mounts, progress_callback, cachedir)
         repos[0].enableInitrdCreation()

--- a/repository.py
+++ b/repository.py
@@ -239,7 +239,7 @@ class MainYumRepository(YumRepositoryWithInfo):
     """Represents a Yum repository containing the main XenServer installation."""
 
     INFO_FILENAME = ".treeinfo"
-    _targets = ['@xenserver_base', '@xenserver_dom0']
+    _targets = ['xcp-ng-deps']
 
     def __init__(self, accessor):
         super(MainYumRepository, self).__init__(accessor)

--- a/repository.py
+++ b/repository.py
@@ -879,9 +879,10 @@ def installFromYum(targets, mounts, progress_callback, cachedir):
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))
 
-def installFromRepos(progress_callback, repos, mounts):
+def installFromRepos(progress_callback, repos, mounts, kernel_alt):
     """Install from a stacked set of repositories"""
 
+    logger.log("installFromRepos, kernel_alt=%s" % (kernel_alt,))
     cachedir = "var/cache/yum/installer"
     for repo in repos:
         repo._accessor.start()
@@ -914,6 +915,8 @@ baseurl=%s
             if repo._targets:
                 targets += repo._targets
         targets = list(set(targets))
+        if kernel_alt:
+            targets.append('kernel-alt')
 
         installFromYum(targets, mounts, progress_callback, cachedir)
         repos[0].enableInitrdCreation()

--- a/repository.py
+++ b/repository.py
@@ -188,7 +188,8 @@ class YumRepository(Repository):
         assert self._targets is not None
         url = self._accessor.url()
         logger.log("URL: " + str(url))
-        with open('/root/yum.conf', 'w') as yum_conf:
+        yum_conf_path = '/root/yum.conf'
+        with open(yum_conf_path, 'w') as yum_conf:
             yum_conf.write(self._yum_conf)
             yum_conf.write("""
 [install]
@@ -206,7 +207,7 @@ baseurl=%s
                 yum_conf.write(repo_config)
 
         self.disableInitrdCreation(mounts['root'])
-        installFromYum(self._targets, mounts, progress_callback, self._cachedir)
+        installFromYum(yum_conf_path, self._targets, mounts, progress_callback, self._cachedir)
         self.enableInitrdCreation()
 
     def installPackages(self, progress_callback, mounts):
@@ -428,7 +429,8 @@ history_record=false
     def isRepo(cls, accessor):
         if UpdateYumRepository.isRepo(accessor):
             url = accessor.url()
-            with open('/root/yum.conf', 'w') as yum_conf:
+            yum_conf_path = '/root/yum.conf'
+            with open(yum_conf_path, 'w') as yum_conf:
                 yum_conf.write(cls._yum_conf)
                 yum_conf.write("""
 [driverrepo]
@@ -443,7 +445,7 @@ baseurl=%s
                     yum_conf.write("password=%s\n" % (url.getPassword(),))
 
             # Check that the drivers group exists in the repo.
-            rv, out = util.runCmd2(['yum', '-c', '/root/yum.conf',
+            rv, out = util.runCmd2(['yum', '-c', yum_conf_path,
                                     'group', 'summary', 'drivers'], with_stdout=True)
             if rv == 0 and 'Groups: 1\n' in out.strip():
                 return True
@@ -801,11 +803,11 @@ def findRepositoriesOnMedia(drivers=False):
 
     return repos
 
-def installFromYum(targets, mounts, progress_callback, cachedir):
+def installFromYum(yum_conf_path, targets, mounts, progress_callback, cachedir):
         # Use a temporary file to avoid deadlocking
         stderr = tempfile.TemporaryFile()
 
-        yum_command = ['yum', '-c', '/root/yum.conf',
+        yum_command = ['yum', '-c', yum_conf_path,
                        '--installroot', mounts['root'],
                        'install', '-y'] + targets
         logger.log("Running yum: %s" % ' '.join(yum_command))
@@ -884,12 +886,14 @@ def installFromRepos(progress_callback, repos, mounts, kernel_alt, linstor_versi
 
     logger.log("installFromRepos, kernel_alt=%s" % (kernel_alt,))
     cachedir = "var/cache/yum/installer"
+    yum_conf_path = '/root/yum.conf'
+
     for repo in repos:
         repo._accessor.start()
 
     try:
         # Build a yum config
-        with open('/root/yum.conf', 'w') as yum_conf:
+        with open(yum_conf_path, 'w') as yum_conf:
             yum_conf.write(_generateYumConf(cachedir))
             for repo in repos:
                 url = repo._accessor.url()
@@ -923,7 +927,7 @@ baseurl=%s
                             'linstor-controller-%s' % linstor_version,
                             ])
 
-        installFromYum(targets, mounts, progress_callback, cachedir)
+        installFromYum(yum_conf_path, targets, mounts, progress_callback, cachedir)
         repos[0].enableInitrdCreation()
     finally:
         for repo in repos:

--- a/repository.py
+++ b/repository.py
@@ -306,12 +306,13 @@ class MainYumRepository(YumRepositoryWithInfo):
         self._parse_repodata(accessor)
         accessor.finish()
 
-    def _repo_config(self):
+    def _repo_config(self, repogpgcheck_override=None):
         if len(self.keyfiles) > 0:
             # Only deal with a single key for the repo
             keyfile = self.keyfiles[0]
             infh = None
             outfh = None
+            repo_gpg_check = int(self._repo_gpg_check) if repogpgcheck_override is None else repogpgcheck_override
             try:
                 infh = self._accessor.openAddress(keyfile)
                 key_path = os.path.join('/root', os.path.basename(keyfile))
@@ -321,7 +322,7 @@ class MainYumRepository(YumRepositoryWithInfo):
 gpgcheck=%s
 repo_gpgcheck=%s
 gpgkey=file://%s
-""" % (int(self._gpg_check), int(self._repo_gpg_check), key_path)
+""" % (int(self._gpg_check), repo_gpg_check, key_path)
             finally:
                 if infh:
                     infh.close()
@@ -881,7 +882,7 @@ def installFromYum(yum_conf_path, targets, mounts, progress_callback, cachedir):
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))
 
-def createMainYumConfig(yum_conf_path, repos, cachedir):
+def createMainYumConfig(yum_conf_path, repos, cachedir, repogpgcheck_override=None):
     with open(yum_conf_path, 'w') as yum_conf:
         yum_conf.write(_generateYumConf(cachedir))
         for repo in repos:
@@ -897,7 +898,7 @@ baseurl=%s
             password = url.getPassword()
             if password is not None:
                 yum_conf.write("password=%s\n" % (url.getPassword(),))
-            repo_config = repo._repo_config()
+            repo_config = repo._repo_config(repogpgcheck_override=repogpgcheck_override)
             if repo_config is not None:
                 yum_conf.write(repo_config)
 
@@ -950,7 +951,7 @@ def listPackagesFromRepos(repos, rpm_pattern, query_format='%{nevr}'):
         repo._accessor.start()
 
     try:
-        createMainYumConfig(yum_conf_path, repos, cachedir)
+        createMainYumConfig(yum_conf_path, repos, cachedir, repogpgcheck_override=0)
 
         rv, out = util.runCmd2(['repoquery', '-c', yum_conf_path,
                                 '--qf', query_format,

--- a/repository.py
+++ b/repository.py
@@ -245,6 +245,7 @@ class MainYumRepository(YumRepositoryWithInfo):
         super(MainYumRepository, self).__init__(accessor)
         self._identifier = MAIN_REPOSITORY_NAME
         self.keyfiles = []
+        self._repo_gpg_check = True
 
         def get_name_version(config_parser, section, name_key, vesion_key):
             name, version = None, None
@@ -316,9 +317,9 @@ class MainYumRepository(YumRepositoryWithInfo):
                 outfh.write(infh.read())
                 return """
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=%s
 gpgkey=file://%s
-""" % (key_path)
+""" % (int(self._repo_gpg_check), key_path)
             finally:
                 if infh:
                     infh.close()
@@ -354,6 +355,9 @@ gpgkey=file://%s
             branding['product-build'] = self._build_number
         return branding
 
+    def setRepoGpgCheck(self, value):
+        logger.log("%s: setRepoGpgCheck(%s)" % (self, value))
+        self._repo_gpg_check = value
 
 class UpdateYumRepository(YumRepositoryWithInfo):
     """Represents a Yum repository containing packages and associated meta data for an update."""

--- a/restore.py
+++ b/restore.py
@@ -23,7 +23,7 @@ def restoreFromBackup(backup, progress=lambda x: ()):
     bootlabel = None
     disk_device = backup.root_disk
     tool = PartitionTool(disk_device)
-    disk = diskutil.probeDisk(disk_device)
+    disk = diskutil.probeDisk(disk_device, raid_members = diskutil.RAID_MEMBERS_PROBE_MEMBER)
     create_sr_part = disk.storage[0] is not None
     boot_partnum = tool.partitionNumber(disk.boot[1]) if disk.boot[0] else -1
 

--- a/tui/__init__.py
+++ b/tui/__init__.py
@@ -8,6 +8,7 @@ import traceback
 import constants
 import sys
 from xcp import logger
+import platform
 
 screen = None
 help_pad = [33, 17, 16]
@@ -28,7 +29,7 @@ To advance to the next screen navigate to the Ok button and press Enter or press
 def init_ui():
     global screen
     screen = SnackScreen()
-    screen.drawRootText(0, 0, "Welcome to %s - Version %s" % (PRODUCT_BRAND or PLATFORM_NAME, PRODUCT_VERSION_TEXT))
+    screen.drawRootText(0, 0, "Welcome to %s - Version %s (Kernel %s)" % (PRODUCT_BRAND or PLATFORM_NAME, PRODUCT_VERSION_TEXT, platform.release()))
     if PRODUCT_BRAND:
         if len(COPYRIGHT_YEARS) > 0:
             screen.drawRootText(0, 1, "Copyright (c) %s %s" % (COPYRIGHT_YEARS, COMPANY_NAME_LEGAL))

--- a/tui/installer/__init__.py
+++ b/tui/installer/__init__.py
@@ -131,6 +131,7 @@ def runMainSequence(results, ram_warning, vt_warning, suppress_extra_cd_dialog):
         results['preserve-settings'] = False
 
     seq = [
+        Step(uis.kernel_warning),
         Step(uis.welcome_screen),
         Step(uis.eula_screen),
         Step(uis.hardware_warnings,

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -99,6 +99,9 @@ To setup advanced storage classes press <F10>.
             tui.fcoe.select_fcoe_ifaces(answers)
             tui.update_help_line([None, "<F9> load driver"])
 
+    if driver_answers['driver-repos']:
+        answers['driver-repos'] = driver_answers['driver-repos']
+
     tui.screen.popHelpLine()
 
     if button == 'reboot':

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -41,6 +41,30 @@ def selectDefault(key, entries):
             return text, k
     return None
 
+# kernel-alt warning
+def kernel_warning(answers):
+    if answers.get("kernel-alt"):
+        button = snackutil.ButtonChoiceWindowEx(
+            tui.screen,
+            "Alternate kernel",
+            """WARNING: you chose to install our alternative kernel (kernel-alt).
+
+This kernel is only provided for debugging purposes.
+
+It is based on our main kernel + upstream kernel.org patches, so it should be stable by construction. However it receives less testing than the main kernel, and is not security-supported.
+
+A boot menu entry for kernel-alt will be added, but we will still boot the main kernel by default.
+
+If kernel-alt works BETTER than the main kernel for you, TELL US so that we may fix the main kernel!
+""",
+            ['Ok', 'Reboot'], width=60)
+
+        if button == 'ok' or button is None:
+            return True
+        else:
+            return EXIT
+    return True
+
 # welcome screen:
 def welcome_screen(answers):
     driver_answers = {'driver-repos': []}

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -794,11 +794,12 @@ def get_sr_type(answers):
                                    for disk in guest_disks)
 
     if not need_large_block_sr_type or not constants.SR_TYPE_LARGE_BLOCK:
-        srtype = answers.get('sr-type', constants.SR_TYPE_LVM)
-        rb = RadioBar(tui.screen, (("LVM: block based. Thick provisioning.",
+        srtype = answers.get('sr-type', constants.SR_TYPE_EXT)
+        rb = RadioBar(tui.screen, (("EXT: file based. Thin provisioning.",
+                                    constants.SR_TYPE_EXT, srtype == constants.SR_TYPE_EXT),
+                                   ("LVM: block based. Thick provisioning.",
                                     constants.SR_TYPE_LVM, srtype == constants.SR_TYPE_LVM),
-                                   ("EXT: file based. Thin provisioning.",
-                                    constants.SR_TYPE_EXT, srtype == constants.SR_TYPE_EXT)))
+                                   ))
         content = rb
         get_type = lambda: rb.getSelection()
         buttons = ButtonBar(tui.screen, [('Ok', 'ok'), ('Back', 'back')])

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -538,7 +538,7 @@ def disk_more_info(context):
     if not context: return True
 
     usage = 'unknown'
-    disk = diskutil.probeDisk(context)
+    disk = diskutil.probeDisk(context, raid_members = diskutil.RAID_MEMBERS_DONT_PROBE)
     if disk.root[0]:
         usage = "%s installation" % MY_PRODUCT_BRAND
     elif disk.storage[0]:
@@ -621,7 +621,7 @@ You may need to change your system settings to boot from this disk.""" % (MY_PRO
 
     # entry contains the 'de' part of the tuple passed in
     # determine current usage
-    disk = diskutil.probeDisk(entry)
+    disk = diskutil.probeDisk(entry, raid_members = diskutil.RAID_MEMBERS_PROBE_RAID)
     if disk.storage[0]:
         if confirm_disk_erase(entry) == 'no':
             return REPEAT_STEP
@@ -732,7 +732,7 @@ def select_guest_disks(answers):
         if i == answers['primary-disk']:
             continue
 
-        disk = diskutil.probeDisk(i)
+        disk = diskutil.probeDisk(i, raid_members = diskutil.RAID_MEMBERS_PROBE_RAID)
         if disk.storage[0]:
             if confirm_disk_erase(i) == 'no':
                 return REPEAT_STEP

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -881,7 +881,7 @@ def get_name_service_configuration(answers):
         for entry in [ns1_entry, ns2_entry, ns3_entry]:
             entry.setFlags(FLAG_DISABLED, enabled)
 
-    hide_rb = answers['net-admin-configuration'].isStatic()
+    hide_rb = answers['net-admin-configuration'].isStatic4()
 
     # HOSTNAME:
     hn_title = Textbox(len("Hostname Configuration"), 1, "Hostname Configuration")
@@ -1011,7 +1011,7 @@ def get_name_service_configuration(answers):
                 answers['manual-nameservers'][1].append(ns2_entry.value())
                 if ns3_entry.value() != '':
                     answers['manual-nameservers'][1].append(ns3_entry.value())
-            if 'net-admin-configuration' in answers and answers['net-admin-configuration'].isStatic():
+            if 'net-admin-configuration' in answers and answers['net-admin-configuration'].isStatic4():
                 answers['net-admin-configuration'].dns = answers['manual-nameservers'][1]
         else:
             answers['manual-nameservers'] = (False, None)
@@ -1094,7 +1094,7 @@ def get_time_configuration_method(answers):
     default = None
     if "ntp-config-method" in answers:
         default = selectDefault(answers['ntp-config-method'], entries)
-    if answers['net-admin-configuration'].isStatic():
+    if answers['net-admin-configuration'].isStatic4():
         default = ENTRY_DEFAULT_NTP
 
     (button, entry) = ListboxChoiceWindow(

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -510,10 +510,14 @@ def confirm_erase_volume_groups(answers):
     return RIGHT_FORWARDS
 
 def use_extra_media(answers):
+    message = "Would you like to install any Supplemental Packs?"
+    if "driver-repos" in answers:
+        message += ("  You previously loaded one or more Driver Disks, if you wish to"
+                    " include these drivers on the installed system, you must install them now.")
     rc = snackutil.ButtonChoiceWindowEx(
         tui.screen,
         "Supplemental Packs",
-        "Would you like to install any Supplemental Packs?",
+        message,
         ['Yes', 'No'],
         default=1, help='suppack'
         )

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -881,7 +881,7 @@ def get_name_service_configuration(answers):
         for entry in [ns1_entry, ns2_entry, ns3_entry]:
             entry.setFlags(FLAG_DISABLED, enabled)
 
-    hide_rb = answers['net-admin-configuration'].isStatic4()
+    hide_rb = not answers['net-admin-configuration'].isDynamic()
 
     # HOSTNAME:
     hn_title = Textbox(len("Hostname Configuration"), 1, "Hostname Configuration")
@@ -1011,7 +1011,7 @@ def get_name_service_configuration(answers):
                 answers['manual-nameservers'][1].append(ns2_entry.value())
                 if ns3_entry.value() != '':
                     answers['manual-nameservers'][1].append(ns3_entry.value())
-            if 'net-admin-configuration' in answers and answers['net-admin-configuration'].isStatic4():
+            if 'net-admin-configuration' in answers and not answers['net-admin-configuration'].isDynamic():
                 answers['net-admin-configuration'].dns = answers['manual-nameservers'][1]
         else:
             answers['manual-nameservers'] = (False, None)
@@ -1094,7 +1094,7 @@ def get_time_configuration_method(answers):
     default = None
     if "ntp-config-method" in answers:
         default = selectDefault(answers['ntp-config-method'], entries)
-    if answers['net-admin-configuration'].isStatic4():
+    if not answers['net-admin-configuration'].isDynamic():
         default = ENTRY_DEFAULT_NTP
 
     (button, entry) = ListboxChoiceWindow(

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -565,6 +565,52 @@ def setup_runtime_networking(answers):
     # Get the answers from the user
     return tui.network.requireNetworking(answers, defaults)
 
+def raid_array_ui(answers):
+    disk_entries = [e for e in sorted_disk_list() if not diskutil.is_raid(e)]
+    raid_disks = [de for de in disk_entries if diskutil.is_raid(de)]
+    raid_slaves = [slave for master in raid_disks for slave in diskutil.getDeviceSlaves(master)]
+    entries = []
+    for de in disk_entries:
+        if de not in raid_slaves and de not in raid_disks:
+            vendor, model, size = diskutil.getExtendedDiskInfo(de)
+            string_entry = "%s - %s [%s %s]" % (
+                diskutil.getHumanDiskName(de), diskutil.getHumanDiskSize(size), vendor, model)
+            entries.append((string_entry, de))
+    if len(entries) < 2:
+        logger.info("not enough disk entries, skipping raid screen")
+        return SKIP_SCREEN
+    text = TextboxReflowed(54, "Do you want to group disks in a software RAID 1 array?  \n\n" +
+                           "The array will be created immediately and erase all the target disks.")
+    buttons = ButtonBar(tui.screen, [('Create', 'create'), ('Back', 'back')])
+    scroll, _ = snackutil.scrollHeight(3, len(entries))
+    cbt = CheckboxTree(3, scroll)
+    for (c_text, c_item) in entries:
+        cbt.append(c_text, c_item, False)
+    gf = GridFormHelp(tui.screen, 'RAID Array', 'guestdisk:info', 1, 4)
+    gf.add(text, 0, 0, padding=(0, 0, 0, 1))
+    gf.add(cbt, 0, 1, padding=(0, 0, 0, 1))
+    gf.add(buttons, 0, 3, growx=1)
+    gf.addHotKey('F5')
+
+    tui.update_help_line([None, "<F5> disk info"])
+    loop = True
+    while loop:
+        rc = gf.run()
+        if rc == 'F5':
+            disk_more_info(cbt.getCurrent())
+        else:
+            loop = False
+    tui.screen.popWindow()
+    tui.screen.popHelpLine()
+
+    answers['swraid'] = True
+    answers['physical-disks'] = cbt.getSelection()
+    answers['primary-disk'] = ""
+    tui.progress.clearModelessDialog()
+
+    logger.info("raid_array_ui: selected %s", answers['physical-disks'])
+    return RIGHT_FORWARDS
+
 def disk_more_info(context):
     if not context: return True
 
@@ -587,8 +633,10 @@ def disk_more_info(context):
     return True
 
 def sorted_disk_list():
-    return sorted(diskutil.getQualifiedDiskList(),
-                  lambda x, y: len(x) == len(y) and cmp(x,y) or (len(x)-len(y)))
+    return [e for e in
+            sorted(set(diskutil.getQualifiedDiskList()),
+                   lambda x, y: len(x) == len(y) and cmp(x,y) or (len(x)-len(y)))
+            if not diskutil.is_raid(e)]
 
 def confirm_disk_erase(disk):
     sr_overwrite_msg = """The selected disk, {}, contains a storage repository. The storage repository may currently be used by other hosts.
@@ -605,7 +653,8 @@ Are you sure you want to continue?"""
 # select drive to use as the Dom0 disk:
 def select_primary_disk(answers):
     button = None
-    diskEntries = sorted_disk_list()
+    diskEntries = ["RAID"] if answers.get('swraid', False) else []
+    diskEntries += sorted_disk_list()
 
     entries = []
     min_primary_disk_size = constants.min_primary_disk_size
@@ -635,6 +684,12 @@ def select_primary_disk(answers):
 
     tui.update_help_line([None, "<F5> more info"])
 
+    if len(entries) < 2:
+        logger.log("not enough disks, not proposing RAID creation")
+        propose_raid = False
+    else:
+        propose_raid = True
+
     scroll, height = snackutil.scrollHeight(4, len(entries))
     (button, entry) = snackutil.ListboxChoiceWindowEx(
         tui.screen,
@@ -643,12 +698,16 @@ def select_primary_disk(answers):
 
 You may need to change your system settings to boot from this disk.""" % (MY_PRODUCT_BRAND),
         entries,
-        ['Ok', 'Back'], 55, scroll, height, default, help='pridisk:info',
+        ['Ok', 'Software RAID', 'Back'] if propose_raid else ['Ok', 'Back'],
+        55, scroll, height, default, help='pridisk:info',
         hotkeys={'F5': disk_more_info})
 
     tui.screen.popHelpLine()
 
     if button == 'back': return LEFT_BACKWARDS
+
+    if button == 'software raid':
+        return raid_array_ui(answers)
 
     # entry contains the 'de' part of the tuple passed in
     # determine current usage
@@ -705,7 +764,8 @@ def check_sr_space(answers):
     return EXIT
 
 def select_guest_disks(answers):
-    diskEntries = sorted_disk_list()
+    diskEntries = ["RAID"] if answers.get('swraid', False) else []
+    diskEntries += sorted_disk_list()
 
     # CA-38329: filter out device mapper nodes (except primary disk) as these won't exist
     # at XenServer boot and therefore cannot be added as physical volumes to Local SR.
@@ -727,6 +787,9 @@ def select_guest_disks(answers):
     # Make a list of entries: (text, item)
     entries = []
     for de in diskEntries:
+        if de == 'RAID':
+            entries.append(("New RAID (%s)" % (','.join(answers['physical-disks']),), de))
+            continue
         entries.append((diskutil.getHumanDiskLabel(de), de))
 
     text = TextboxReflowed(54, "Which disks do you want to use for %s storage?  \n\nOne storage repository will be created that spans the selected disks.  You can choose not to prepare any storage if you want to create an advanced configuration after installation." % BRAND_GUEST)
@@ -758,7 +821,15 @@ def select_guest_disks(answers):
 
     if button == 'back': return LEFT_BACKWARDS
 
-    for i in cbt.getSelection():
+    selected_disks = cbt.getSelection()
+    physical_selected_disks = cbt.getSelection()
+    if "RAID" in selected_disks:
+        selected_disks.remove("RAID")
+        selected_disks.append("/dev/md127")
+        physical_selected_disks.remove("RAID")
+        physical_selected_disks += answers['physical-disks']
+
+    for i in physical_selected_disks:
         # The user has already confirmed the primary disk
         if i == answers['primary-disk']:
             continue
@@ -768,8 +839,9 @@ def select_guest_disks(answers):
             if confirm_disk_erase(i) == 'no':
                 return REPEAT_STEP
 
-    answers['guest-disks'] = cbt.getSelection()
-    answers['sr-on-primary'] = answers['primary-disk'] in answers['guest-disks']
+    answers['guest-disks'] = selected_disks
+    answers['sr-on-primary'] = (answers['primary-disk'] in answers['guest-disks']
+                                or '/dev/md127' in answers['guest-disks'])
 
     # if the user select no disks for guest storage, check this is what
     # they wanted:
@@ -791,7 +863,10 @@ def get_sr_type(answers):
     assert guest_disks is not None
 
     need_large_block_sr_type = any(diskutil.isLargeBlockDisk(disk)
-                                   for disk in guest_disks)
+                                   for disk in guest_disks if disk != "/dev/md127")
+    if "/dev/md127" in guest_disks:
+        need_large_block_sr_type |= any(diskutil.isLargeBlockDisk(disk)
+                                        for disk in answers['physical-disks'])
 
     if not need_large_block_sr_type or not constants.SR_TYPE_LARGE_BLOCK:
         srtype = answers.get('sr-type', constants.SR_TYPE_EXT)

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -795,12 +795,12 @@ def get_sr_type(answers):
 
     if not need_large_block_sr_type or not constants.SR_TYPE_LARGE_BLOCK:
         srtype = answers.get('sr-type', constants.SR_TYPE_LVM)
-        txt = "Enable thin provisioning"
-        if len(BRAND_VDI) > 0:
-            txt += " (Optimized storage for %s)" % BRAND_VDI
-        tb = Checkbox(txt, srtype == constants.SR_TYPE_EXT and 1 or 0)
-        content = tb
-        get_type = lambda: tb.selected() and constants.SR_TYPE_EXT or constants.SR_TYPE_LVM
+        rb = RadioBar(tui.screen, (("LVM: block based. Thick provisioning.",
+                                    constants.SR_TYPE_LVM, srtype == constants.SR_TYPE_LVM),
+                                   ("EXT: file based. Thin provisioning.",
+                                    constants.SR_TYPE_EXT, srtype == constants.SR_TYPE_EXT)))
+        content = rb
+        get_type = lambda: rb.getSelection()
         buttons = ButtonBar(tui.screen, [('Ok', 'ok'), ('Back', 'back')])
     else:
         content = TextboxReflowed(40,

--- a/tui/network.py
+++ b/tui/network.py
@@ -34,7 +34,7 @@ def get_iface_configuration(nic, txt=None, defaults=None, include_dns=False):
     dns_field = Entry(16)
     vlan_field = Entry(16)
 
-    if defaults and defaults.isStatic():
+    if defaults and defaults.isStatic4():
         # static configuration defined previously
         dhcp_rb = SingleRadioButton("Automatic configuration (DHCP)", None, 0)
         dhcp_rb.setCallback(dhcp_change, ())

--- a/tui/network.py
+++ b/tui/network.py
@@ -9,128 +9,215 @@ import netutil
 from netinterface import *
 import version
 import os
+import time
+import socket
 
 from snack import *
 
 def get_iface_configuration(nic, txt=None, defaults=None, include_dns=False):
+    def choose_primary_address_type(nic):
+        gf = GridFormHelp(tui.screen, 'Networking', 'Address type', 1, 8)
+        txt = "Choose an address type for %s (%s)" % (nic.name, nic.hwaddr)
+        text = TextboxReflowed(45, txt)
 
-    def use_vlan_cb_change():
-        vlan_field.setFlags(FLAG_DISABLED, vlan_cb.value())
+        b = [("Ok", "ok"), ("Back", "back")]
+        buttons = ButtonBar(tui.screen, b)
 
-    def dhcp_change():
-        for x in [ ip_field, gateway_field, subnet_field, dns_field ]:
-            x.setFlags(FLAG_DISABLED, not dhcp_rb.selected())
+        # IPv4 by default
+        ipv4_rb = SingleRadioButton("IPv4", None, 1)
+        ipv6_rb = SingleRadioButton("IPv6", ipv4_rb, 0)
+        dual_rb = SingleRadioButton("Dual stack (IPv4 primary)", ipv6_rb, 0)
 
-    gf = GridFormHelp(tui.screen, 'Networking', 'ifconfig', 1, 8)
-    if txt is None:
-        txt = "Configuration for %s (%s)" % (nic.name, nic.hwaddr)
-    text = TextboxReflowed(45, txt)
-    b = [("Ok", "ok"), ("Back", "back")]
-    buttons = ButtonBar(tui.screen, b)
+        gf.add(text, 0, 0, padding=(0, 0, 0, 1))
+        gf.add(ipv4_rb, 0, 2, anchorLeft=True)
+        gf.add(ipv6_rb, 0, 3, anchorLeft=True)
+        gf.add(dual_rb, 0, 4, anchorLeft=True)
+        gf.add(buttons, 0, 5, growx=1)
 
-    ip_field = Entry(16)
-    subnet_field = Entry(16)
-    gateway_field = Entry(16)
-    dns_field = Entry(16)
-    vlan_field = Entry(16)
+        loop = True
+        direction = LEFT_BACKWARDS
+        address_type = None
+        while loop:
+            result = gf.run()
+            if buttons.buttonPressed(result) == 'back':
+                loop = False
+            elif buttons.buttonPressed(result) == 'ok':
+                value = None
+                if ipv4_rb.selected():
+                    value = "ipv4"
+                elif ipv6_rb.selected():
+                    value = "ipv6"
+                elif dual_rb.selected():
+                    value = "dual"
+                loop = False
+                direction = RIGHT_FORWARDS
+                address_type = value
 
-    if defaults and defaults.isStatic4():
-        # static configuration defined previously
-        dhcp_rb = SingleRadioButton("Automatic configuration (DHCP)", None, 0)
+        tui.screen.popWindow()
+        return direction, address_type
+
+    def get_ip_configuration(nic, txt, defaults, include_dns, iface_class):
+        def use_vlan_cb_change():
+            vlan_field.setFlags(FLAG_DISABLED, vlan_cb.value())
+
+        def dhcp_change():
+            for x in [ ip_field, gateway_field, subnet_field, dns_field ]:
+                x.setFlags(FLAG_DISABLED, static_rb.selected())
+
+        ipv6 = iface_class == NetInterfaceV6
+
+        gf = GridFormHelp(tui.screen, 'Networking', 'ifconfig', 1, 10)
+        if txt is None:
+            txt = "Configuration for %s (%s)" % (nic.name, nic.hwaddr)
+        text = TextboxReflowed(45, txt)
+        b = [("Ok", "ok"), ("Back", "back")]
+        buttons = ButtonBar(tui.screen, b)
+
+        #TODO? Change size for IPv6? If so which size?
+        ip_field = Entry(16)
+        subnet_field = Entry(16)
+        gateway_field = Entry(16)
+        dns_field = Entry(16)
+        vlan_field = Entry(16)
+
+        static = bool(defaults and (defaults.modev6 if ipv6 else defaults.mode) == NetInterface.Static)
+        dhcp_rb = SingleRadioButton("Automatic configuration (DHCP)", None, not static)
         dhcp_rb.setCallback(dhcp_change, ())
-        static_rb = SingleRadioButton("Static configuration:", dhcp_rb, 1)
+        static_rb = SingleRadioButton("Static configuration:", dhcp_rb, static)
         static_rb.setCallback(dhcp_change, ())
-        if defaults.ipaddr:
-            ip_field.set(defaults.ipaddr)
-        if defaults.netmask:
-            subnet_field.set(defaults.netmask)
-        if defaults.gateway:
-            gateway_field.set(defaults.gateway)
-        if defaults.dns:
-            dns_field.set(defaults.dns[0])
-    else:
-        dhcp_rb = SingleRadioButton("Automatic configuration (DHCP)", None, 1)
-        dhcp_rb.setCallback(dhcp_change, ())
-        static_rb = SingleRadioButton("Static configuration:", dhcp_rb, 0)
-        static_rb.setCallback(dhcp_change, ())
-        ip_field.setFlags(FLAG_DISABLED, False)
-        subnet_field.setFlags(FLAG_DISABLED, False)
-        gateway_field.setFlags(FLAG_DISABLED, False)
-        dns_field.setFlags(FLAG_DISABLED, False)
+        if ipv6:
+            autoconf_rb = SingleRadioButton("Automatic configuration (Autoconf)", static_rb, 0)
+            autoconf_rb.setCallback(dhcp_change, ())
+        dhcp_change()
 
-    vlan_cb = Checkbox("Use VLAN:", defaults.isVlan() if defaults else False)
-    vlan_cb.setCallback(use_vlan_cb_change, ())
-    if defaults and defaults.isVlan():
-        vlan_field.set(str(defaults.vlan))
-    else:
-        vlan_field.setFlags(FLAG_DISABLED, False)
+        if defaults:
+            if ipv6:
+                if defaults.ipv6addr:
+                    ip6addr, netmask = defaults.ipv6addr.split("/")
+                    ip_field.set(ip6addr)
+                    subnet_field.set(netmask)
+                if defaults.ipv6_gateway:
+                    gateway_field.set(defaults.ipv6_gateway)
+            else:
+                if defaults.ipaddr:
+                    ip_field.set(defaults.ipaddr)
+                if defaults.netmask:
+                    subnet_field.set(defaults.netmask)
+                if defaults.gateway:
+                    gateway_field.set(defaults.gateway)
 
-    ip_text = Textbox(15, 1, "IP Address:")
-    subnet_text = Textbox(15, 1, "Subnet mask:")
-    gateway_text = Textbox(15, 1, "Gateway:")
-    dns_text = Textbox(15, 1, "Nameserver:")
-    vlan_text = Textbox(15, 1, "VLAN (1-4094):")
+            if defaults.dns:
+                dns_field.set(defaults.dns[0])
 
-    entry_grid = Grid(2, include_dns and 4 or 3)
-    entry_grid.setField(ip_text, 0, 0)
-    entry_grid.setField(ip_field, 1, 0)
-    entry_grid.setField(subnet_text, 0, 1)
-    entry_grid.setField(subnet_field, 1, 1)
-    entry_grid.setField(gateway_text, 0, 2)
-    entry_grid.setField(gateway_field, 1, 2)
-    if include_dns:
-        entry_grid.setField(dns_text, 0, 3)
-        entry_grid.setField(dns_field, 1, 3)
+        vlan_cb = Checkbox("Use VLAN:", defaults.isVlan() if defaults else False)
+        vlan_cb.setCallback(use_vlan_cb_change, ())
+        if defaults and defaults.isVlan():
+            vlan_field.set(str(defaults.vlan))
+        else:
+            vlan_field.setFlags(FLAG_DISABLED, False)
 
-    vlan_grid =  Grid(2, 1)
-    vlan_grid.setField(vlan_text, 0, 0)
-    vlan_grid.setField(vlan_field, 1, 0)
+        ip_msg = "IPv6 Address" if ipv6 else "IP Address"
+        mask_msg = "CIDR (4-128)" if ipv6 else "Subnet mask"
+        ip_text = Textbox(15, 1, "%s:" % ip_msg)
+        subnet_text = Textbox(15, 1, "%s:" % mask_msg)
+        gateway_text = Textbox(15, 1, "Gateway:")
+        dns_text = Textbox(15, 1, "Nameserver:")
+        vlan_text = Textbox(15, 1, "VLAN (1-4094):")
 
-    gf.add(text, 0, 0, padding=(0, 0, 0, 1))
-    gf.add(dhcp_rb, 0, 2, anchorLeft=True)
-    gf.add(static_rb, 0, 3, anchorLeft=True)
-    gf.add(entry_grid, 0, 4, padding=(0, 0, 0, 1))
-    gf.add(vlan_cb, 0, 5, anchorLeft=True)
-    gf.add(vlan_grid, 0, 6, padding=(0, 0, 0, 1))
-    gf.add(buttons, 0, 7, growx=1)
+        entry_grid = Grid(2, include_dns and 4 or 3)
+        entry_grid.setField(ip_text, 0, 0)
+        entry_grid.setField(ip_field, 1, 0)
+        entry_grid.setField(subnet_text, 0, 1)
+        entry_grid.setField(subnet_field, 1, 1)
+        entry_grid.setField(gateway_text, 0, 2)
+        entry_grid.setField(gateway_field, 1, 2)
+        if include_dns:
+            entry_grid.setField(dns_text, 0, 3)
+            entry_grid.setField(dns_field, 1, 3)
 
-    loop = True
-    while loop:
-        result = gf.run()
+        vlan_grid =  Grid(2, 1)
+        vlan_grid.setField(vlan_text, 0, 0)
+        vlan_grid.setField(vlan_field, 1, 0)
 
-        if buttons.buttonPressed(result) in ['ok', None]:
-            # validate input
-            msg = ''
-            if static_rb.selected():
-                if not netutil.valid_ip_addr(ip_field.value()):
-                    msg = 'IP Address'
-                elif not netutil.valid_ip_addr(subnet_field.value()):
-                    msg = 'Subnet mask'
-                elif gateway_field.value() != '' and not netutil.valid_ip_addr(gateway_field.value()):
-                    msg = 'Gateway'
-                elif dns_field.value() != '' and not netutil.valid_ip_addr(dns_field.value()):
-                    msg = 'Nameserver'
-            if vlan_cb.selected():
-                if not netutil.valid_vlan(vlan_field.value()):
-                    msg = 'VLAN'
-            if msg != '':
-                tui.progress.OKDialog("Networking", "Invalid %s, please check the field and try again." % msg)
+        gf.add(text, 0, 0, padding=(0, 0, 0, 1))
+        gf.add(dhcp_rb, 0, 2, anchorLeft=True)
+        gf.add(static_rb, 0, 3, anchorLeft=True)
+        gf.add(entry_grid, 0, 4, padding=(0, 0, 0, 1))
+        if ipv6:
+            gf.add(autoconf_rb, 0, 5, anchorLeft=True)
+        # One more line for IPv6 autoconf
+        gf.add(vlan_cb, 0, 5 + ipv6, anchorLeft=True)
+        gf.add(vlan_grid, 0, 6 + ipv6, padding=(0, 0, 0, 1))
+        gf.add(buttons, 0, 7 + ipv6, growx=1)
+
+        loop = True
+        ip_family = socket.AF_INET6 if ipv6 else socket.AF_INET
+        while loop:
+            result = gf.run()
+
+            if buttons.buttonPressed(result) in ['ok', None]:
+                # validate input
+                msg = ''
+                if static_rb.selected():
+                    invalid_subnet = int(subnet_field.value()) > 128 or int(subnet_field.value()) < 4 if ipv6 else not netutil.valid_ipv4_addr(subnet_field.value())
+                    if not netutil.valid_ip_address_family(ip_field.value(), ip_family):
+                        msg = ip_msg
+                    elif invalid_subnet:
+                        msg = mask_msg
+                    elif gateway_field.value() != '' and not netutil.valid_ip_address_family(gateway_field.value(), ip_family):
+                        msg = 'Gateway'
+                    elif dns_field.value() != '' and not netutil.valid_ip_address_family(dns_field.value(), ip_family):
+                        msg = 'Nameserver'
+                if vlan_cb.selected():
+                    if not netutil.valid_vlan(vlan_field.value()):
+                        msg = 'VLAN'
+                if msg != '':
+                    tui.progress.OKDialog("Networking", "Invalid %s, please check the field and try again." % msg)
+                else:
+                    loop = False
             else:
                 loop = False
+
+        tui.screen.popWindow()
+
+        if buttons.buttonPressed(result) == 'back': return LEFT_BACKWARDS, None
+
+        vlan_value = int(vlan_field.value()) if vlan_cb.selected() else None
+        if dhcp_rb.selected():
+            answers = iface_class(NetInterface.DHCP, nic.hwaddr, vlan=vlan_value)
+        elif ipv6 and autoconf_rb.selected():
+            answers = iface_class(NetInterface.Autoconf, nic.hwaddr, vlan=vlan_value)
         else:
-            loop = False
+            answers = iface_class(NetInterface.Static, nic.hwaddr, ip_field.value(),
+                            subnet_field.value(), gateway_field.value(),
+                            dns_field.value(), vlan=vlan_value)
 
-    tui.screen.popWindow()
+        return RIGHT_FORWARDS, answers
 
-    if buttons.buttonPressed(result) == 'back': return LEFT_BACKWARDS, None
+    direction, address_type = choose_primary_address_type(nic)
+    if direction == LEFT_BACKWARDS:
+        return LEFT_BACKWARDS, None
 
-    vlan_value = int(vlan_field.value()) if vlan_cb.selected() else None
-    if bool(dhcp_rb.selected()):
-        answers = NetInterface(NetInterface.DHCP, nic.hwaddr, vlan=vlan_value)
-    else:
-        answers = NetInterface(NetInterface.Static, nic.hwaddr, ip_field.value(),
-                               subnet_field.value(), gateway_field.value(),
-                               dns_field.value(), vlan=vlan_value)
+    answers = None
+    if address_type in ["ipv4", "dual"]:
+        direction, answers = get_ip_configuration(nic, txt, defaults, include_dns, NetInterface)
+        if direction == LEFT_BACKWARDS:
+            return LEFT_BACKWARDS, None
+
+    if address_type in ["ipv6", "dual"]:
+        direction, answers_ipv6 = get_ip_configuration(nic, txt, defaults, include_dns, NetInterfaceV6)
+        if direction == LEFT_BACKWARDS:
+            return LEFT_BACKWARDS, None
+
+        if answers == None:
+            answers = answers_ipv6
+        else:
+            answers.modev6 = answers_ipv6.modev6
+            answers.ipv6addr = answers_ipv6.ipv6addr
+            answers.ipv6_gateway = answers_ipv6.ipv6_gateway
+            if answers_ipv6.dns != None:
+                answers.dns = answers_ipv6.dns if answers.dns == None else answers.dns + answers_ipv6.dns
+
     return RIGHT_FORWARDS, answers
 
 def select_netif(text, conf, offer_existing=False, default=None):
@@ -286,23 +373,37 @@ def requireNetworking(answers, defaults=None, msg=None, keys=['net-admin-interfa
         ifaceName = conf_dict['config'].getInterfaceName(conf_dict['interface'])
         netutil.ifdown(ifaceName)
 
-        # check that we have *some* network:
-        if netutil.ifup(ifaceName) != 0 or not netutil.interfaceUp(ifaceName):
+        def display_error():
             tui.progress.clearModelessDialog()
             tui.progress.OKDialog("Networking", "The network still does not appear to be active.  Please check your settings, and try again.")
-            direction = REPEAT_STEP
-        else:
-            if answers and type(answers) == dict:
-                # write out results
-                answers[interface_key] = conf_dict['interface']
-                answers[config_key] = conf_dict['config']
-                # update cache of manual configurations
-                manual_config = {}
-                all_dhcp = False
-                if 'runtime-iface-configuration' in answers:
-                    manual_config = answers['runtime-iface-configuration'][1]
-                manual_config[conf_dict['interface']] = conf_dict['config']
-                answers['runtime-iface-configuration'] = (all_dhcp, manual_config)
-            tui.progress.clearModelessDialog()
+            return REPEAT_STEP
+
+        if netutil.ifup(ifaceName) != 0:
+            return display_error()
+
+        # For Autoconf wait a bit for network setup
+        try_nb = 20 if conf_dict['config'].modev6 == NetInterface.Autoconf else 0
+        while True:
+            if try_nb == 0 or netutil.interfaceUp(ifaceName):
+                break
+            try_nb -= 1
+            time.sleep(0.1)
+
+        # check that we have *some* network:
+        if not netutil.interfaceUp(ifaceName):
+            return display_error()
+
+        if answers and type(answers) == dict:
+            # write out results
+            answers[interface_key] = conf_dict['interface']
+            answers[config_key] = conf_dict['config']
+            # update cache of manual configurations
+            manual_config = {}
+            all_dhcp = False
+            if 'runtime-iface-configuration' in answers:
+                manual_config = answers['runtime-iface-configuration'][1]
+            manual_config[conf_dict['interface']] = conf_dict['config']
+            answers['runtime-iface-configuration'] = (all_dhcp, manual_config)
+        tui.progress.clearModelessDialog()
 
     return direction

--- a/tui/network.py
+++ b/tui/network.py
@@ -26,7 +26,7 @@ def get_iface_configuration(nic, txt=None, defaults=None, include_dns=False):
         # IPv4 by default
         ipv4_rb = SingleRadioButton("IPv4", None, 1)
         ipv6_rb = SingleRadioButton("IPv6", ipv4_rb, 0)
-        dual_rb = SingleRadioButton("Dual stack (IPv4 primary)", ipv6_rb, 0)
+        dual_rb = SingleRadioButton("Dual stack (IPv4 primary) - EXPERIMENTAL", ipv6_rb, 0)
 
         gf.add(text, 0, 0, padding=(0, 0, 0, 1))
         gf.add(ipv4_rb, 0, 2, anchorLeft=True)

--- a/tui/repo.py
+++ b/tui/repo.py
@@ -89,6 +89,9 @@ def select_repo_source(answers, title, text, require_base_repo=True):
     entries = [ ENTRY_LOCAL ]
 
     default = ENTRY_LOCAL
+    if answers.get('netinstall'):
+        entries = []
+        default = ENTRY_URL
     if len(answers['network-hardware'].keys()) > 0:
         entries += [ ENTRY_URL, ENTRY_NFS ]
 
@@ -136,6 +139,8 @@ def get_url_location(answers, require_base_repo):
             user_field.set(answers['source-address'].getUsername())
         if answers['source-address'].getPassword() is not None:
             passwd_field.set(answers['source-address'].getPassword())
+    else:
+        url_field.set('http://mirrors.xcp-ng.org/netinstall/8.2.1')
 
     done = False
     while not done:

--- a/tui/repo.py
+++ b/tui/repo.py
@@ -140,7 +140,7 @@ def get_url_location(answers, require_base_repo):
         if answers['source-address'].getPassword() is not None:
             passwd_field.set(answers['source-address'].getPassword())
     else:
-        url_field.set('http://mirrors.xcp-ng.org/netinstall/8.2.1')
+        url_field.set('http://mirrors.xcp-ng.org/netinstall/8.3')
 
     done = False
     while not done:

--- a/upgrade.py
+++ b/upgrade.py
@@ -592,9 +592,9 @@ class ThirdGenUpgrader(Upgrader):
         finally:
             primary_fs.unmount()
 
-    prepUpgradeArgs = ['installation-uuid', 'control-domain-uuid']
+    prepUpgradeArgs = []
     prepStateChanges = ['installation-uuid', 'control-domain-uuid']
-    def prepareUpgrade(self, progress_callback, installID, controlID):
+    def prepareUpgrade(self, progress_callback):
         """ Try to preserve the installation and control-domain UUIDs from
         xensource-inventory."""
         try:

--- a/upgrade.py
+++ b/upgrade.py
@@ -701,6 +701,9 @@ class ThirdGenUpgrader(Upgrader):
         # XAPI firewall-port plugin
         restore_list += ['etc/sysconfig/iptables']
 
+        # Keep user multipath configuration
+        restore_list += [{'dir': 'etc/multipath/conf.d', 're': re.compile(r'custom.*\.conf')}]
+
         return restore_list
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']

--- a/upgrade.py
+++ b/upgrade.py
@@ -608,7 +608,7 @@ class ThirdGenUpgrader(Upgrader):
             primary_fs.unmount()
 
     prepUpgradeArgs = []
-    prepStateChanges = ['installation-uuid', 'control-domain-uuid', 'management-address-type']
+    prepStateChanges = ['installation-uuid', 'control-domain-uuid', 'management-address-type', 'linstor-version']
     def prepareUpgrade(self, progress_callback):
         """ Try to preserve the installation and control-domain UUIDs from
         xensource-inventory."""
@@ -619,7 +619,7 @@ class ThirdGenUpgrader(Upgrader):
         except KeyError:
             raise RuntimeError("Required information (INSTALLATION_UUID, CONTROL_DOMAIN_UUID, MANAGEMENT_ADDRESS_TYPE) was missing from your xensource-inventory file.  Aborting installation; please replace these keys and try again.")
 
-        return installID, controlID, mgmtAddrType
+        return installID, controlID, mgmtAddrType, self.source.settings['linstor-version']
 
     def buildRestoreList(self, src_base):
         restore_list = []

--- a/upgrade.py
+++ b/upgrade.py
@@ -264,7 +264,10 @@ class ThirdGenUpgrader(Upgrader):
         if tool.partTableType == constants.PARTITION_DOS and utilparts is not None:
             raise RuntimeError("Util partition detected on DOS partition type, upgrade forbidden.")
         if self.key_size < constants.MIN_KEY_SIZE:
-            raise RuntimeError("Current server certificate is too small (%s bits), please regenerate with at least %s bits." % (self.key_size, constants.MIN_KEY_SIZE))
+            raise RuntimeError("Current server certificate is too small (%s bits),"
+                               " please regenerate with at least %s bits.\n\n"
+                               "See the Release Notes for XCP-ng 8.3.0" %
+                               (self.key_size, constants.MIN_KEY_SIZE))
 
     convertTargetStateChanges = []
     convertTargetArgs = ['primary-disk', 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum', 'backup-partnum', 'target-platform']

--- a/upgrade.py
+++ b/upgrade.py
@@ -699,6 +699,13 @@ class ThirdGenUpgrader(Upgrader):
         restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
         restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
 
+        # LINSTOR
+        restore_list += ['etc/drbd-reactor.d/sm-linstor.toml',
+                         'etc/systemd/system/multi-user.target.wants/drbd-reactor.service',
+                         'etc/systemd/system/multi-user.target.wants/linstor-satellite.service',
+                         'etc/systemd/system/multi-user.target.wants/linstor-monitor.service',
+                         ]
+
         # XAPI firewall-port plugin
         restore_list += ['etc/sysconfig/iptables']
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -704,6 +704,9 @@ class ThirdGenUpgrader(Upgrader):
         # Keep user multipath configuration
         restore_list += [{'dir': 'etc/multipath/conf.d', 're': re.compile(r'custom.*\.conf')}]
 
+        # Keep IPv6 enablement/disablement upon upgrades
+        restore_list += ['etc/sysctl.d/91-net-ipv6.conf']
+
         return restore_list
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']

--- a/upgrade.py
+++ b/upgrade.py
@@ -608,17 +608,18 @@ class ThirdGenUpgrader(Upgrader):
             primary_fs.unmount()
 
     prepUpgradeArgs = []
-    prepStateChanges = ['installation-uuid', 'control-domain-uuid']
+    prepStateChanges = ['installation-uuid', 'control-domain-uuid', 'management-address-type']
     def prepareUpgrade(self, progress_callback):
         """ Try to preserve the installation and control-domain UUIDs from
         xensource-inventory."""
         try:
             installID = self.source.getInventoryValue("INSTALLATION_UUID")
             controlID = self.source.getInventoryValue("CONTROL_DOMAIN_UUID")
+            mgmtAddrType = self.source.getInventoryValue("MANAGEMENT_ADDRESS_TYPE")
         except KeyError:
-            raise RuntimeError("Required information (INSTALLATION_UUID, CONTROL_DOMAIN_UUID) was missing from your xensource-inventory file.  Aborting installation; please replace these keys and try again.")
+            raise RuntimeError("Required information (INSTALLATION_UUID, CONTROL_DOMAIN_UUID, MANAGEMENT_ADDRESS_TYPE) was missing from your xensource-inventory file.  Aborting installation; please replace these keys and try again.")
 
-        return installID, controlID
+        return installID, controlID, mgmtAddrType
 
     def buildRestoreList(self, src_base):
         restore_list = []

--- a/upgrade.py
+++ b/upgrade.py
@@ -6,6 +6,8 @@ import os
 import re
 import shutil
 
+from OpenSSL import crypto
+
 import diskutil
 import product
 from xcp.version import *
@@ -247,12 +249,22 @@ class ThirdGenUpgrader(Upgrader):
             input_data = util.readKeyValueFile(default_storage_conf_path)
             self.storage_type = input_data['TYPE']
 
+        self.key_size = None
+        cert_path = os.path.join(primary_fs.mount_point, "etc/xensource/xapi-ssl.pem")
+        with open(cert_path, "r") as cert_file:
+            cert_text = cert_file.read()
+        cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_text)
+        self.key_size = cert.get_pubkey().bits()
+        logger.info("ExistingInstallation %s: certificate key size %s", source, self.key_size)
+
         primary_fs.unmount()
 
     def testUpgradeForbidden(self, tool):
         utilparts = tool.utilityPartitions()
         if tool.partTableType == constants.PARTITION_DOS and utilparts is not None:
             raise RuntimeError("Util partition detected on DOS partition type, upgrade forbidden.")
+        if self.key_size < constants.MIN_KEY_SIZE:
+            raise RuntimeError("Current server certificate is too small (%s bits), please regenerate with at least %s bits." % (self.key_size, constants.MIN_KEY_SIZE))
 
     convertTargetStateChanges = []
     convertTargetArgs = ['primary-disk', 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum', 'backup-partnum', 'target-platform']

--- a/util.py
+++ b/util.py
@@ -360,6 +360,9 @@ def udevinfoCmd():
 def randomLabelStr():
     return "".join([random.choice(string.ascii_lowercase) for x in range(6)])
 
+def getMgmtAddrType():
+    return None
+
 def getLocalTime(timezone=None):
     if timezone:
         os.environ['TZ'] = timezone


### PR DESCRIPTION
This is a rebase of the `10.10.29-8.3` branch, which takes place in 2 steps:
- linearizing history of `10.10.29-8.3` into `ydi/10.10.29-8.3-linearized`
- rebasing of `ydi/10.10.29-8.3-linearized` into this PR

A few small commits have been merged upstream.

The big change here is the new upstream RAID1 support, which clashed with our own implementation. To avoid debugging interactions and maintaining brittle code, this ports the XCP-ng interfaces (answerfile and TUI) to RAID1 onto upstream implementation of `swraid`.

The swraid implementation assembles the raid in the prep stage, after all UI choices were done, so we could not rely on the md device existing to fill the disk-selection dialogs, so we manually add the choice in such dialogs.

Compared to the previous implementation we gain support for creating degraded RAID with a single disk (only using answerfile for now), and for installing without RAID over an existing RAID.
