### PR TITLE
Fix raid support for more than 2 disks, and assorted fixes

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -340,7 +340,7 @@ class Answerfile:
             legacy_raid[disk_device] = disks
 
         if legacy_raid:
-            assert len(legacy_raid) == 1, "Building more than one RAID is no supported any more"
+            assert len(legacy_raid) == 1, "Building more than one RAID is not supported any more"
             # FIXME: the following be problematic, legacy raid had implicit localhost:127 name
             results['primary-disk'] = ""  # Populated with disk-label-suffix during installer prep
             results['physical-disks'] = next(iter(legacy_raid.values()))

--- a/backend.py
+++ b/backend.py
@@ -626,7 +626,7 @@ def setupSWRAIDDevice(disk_label_suffix, physical_disks, guest_disks):
 
     # Create multi-device
     members = [physical_disks[0], 'missing'] if len(physical_disks) == 1 else physical_disks
-    rc = util.runCmd2(['mdadm', '--create', primary_disk, '--size=%sG' % swraidSizeGB, '--metadata=1.0', '--level=mirror', '--raid-devices=2', '--run'] + members)
+    rc = util.runCmd2(['mdadm', '--create', primary_disk, '--size=%sG' % swraidSizeGB, '--metadata=1.0', '--level=mirror', '--raid-devices=%s' % len(members), '--run'] + members)
     if rc != 0:
         raise RuntimeError("Failed to create SWRAID device: '%s' from initial devices: '%s'" % (primary_disk, ','.join(members)))
 

--- a/backend.py
+++ b/backend.py
@@ -624,16 +624,11 @@ def setupSWRAIDDevice(disk_label_suffix, physical_disks, guest_disks):
     sizeGB = int(out.strip()) / (1024 ** 3)
     swraidSizeGB = int(sizeGB * 0.95)
 
-    # Create multi-device with the first physical disk
-    rc = util.runCmd2(['mdadm', '--create', primary_disk, '--size=%sG' % swraidSizeGB, '--metadata=1.0', '--level=mirror', '--raid-devices=2', '--run', physical_disks[0], 'missing'])
+    # Create multi-device
+    members = [physical_disks[0], 'missing'] if len(physical_disks) == 1 else physical_disks
+    rc = util.runCmd2(['mdadm', '--create', primary_disk, '--size=%sG' % swraidSizeGB, '--metadata=1.0', '--level=mirror', '--raid-devices=2', '--run'] + members)
     if rc != 0:
-        raise RuntimeError("Failed to create SWRAID device: '%s' from initial device: '%s'" % (primary_disk, physical_disks[0]))
-
-    if len(physical_disks) == 2:
-        # Add second disk to SW RAID device
-        rc = util.runCmd2(['mdadm', '--manage', primary_disk, '--add', physical_disks[1], '--run'])
-        if rc != 0:
-            raise RuntimeError("Failed to add second disk: '%s' to SWRAID device: '%s'" % (physical_disks[1], primary_disk))
+        raise RuntimeError("Failed to create SWRAID device: '%s' from initial devices: '%s'" % (primary_disk, ','.join(members)))
 
     with open('/proc/sys/dev/raid/speed_limit_max', 'w') as speed_file:
         speed_file.write(str(constants.swraid_speed_write_max))

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -250,6 +250,8 @@ Format of 'source' and 'driver-source'
     This is a legacy XCP-ng-specific syntax, using the "swraid"
     attribute on <primary-disk> is the official way.
 
+    Compared with "swraid", this syntax allows to specify more than
+    two disks, but does not allow to specify a missing disk.
 
   <guest-disks>
     <guest-disk>dev</guest-disk>*

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -764,15 +764,33 @@ def check_sr_space(answers):
     return EXIT
 
 def select_guest_disks(answers):
-    diskEntries = ["RAID"] if answers.get('swraid', False) else []
-    diskEntries += sorted_disk_list()
+    diskEntries = sorted_disk_list()
 
-    # CA-38329: filter out device mapper nodes (except primary disk) as these won't exist
-    # at XenServer boot and therefore cannot be added as physical volumes to Local SR.
-    # Also, since the DM nodes are multipathed SANs it doesn't make sense to include them
-    # in the "Local" SR.
-    allowed_in_local_sr = lambda dev: (dev == answers['primary-disk']) or (not isDeviceMapperNode(dev))
+    logger.info("select_guest_disks: sorted_disk_list=%s isdm=%s primary-disk=%s physical-disks=%s",
+                diskEntries, [d for d in diskEntries if isDeviceMapperNode(d)],
+                answers['primary-disk'], answers['physical-disks'])
+    def allowed_in_local_sr(dev):
+        # primary disk is always allowed, to use the extra free space
+        if dev == answers['primary-disk']:
+            return True
+        # physical disks making up a raid should not be shown (but the
+        # same physical-disks answer is also used outside of raid
+        # context)
+        if answers.get('swraid', False) and dev in answers['physical-disks']:
+            return False
+        # CA-38329: filter out device mapper nodes (except primary disk) as these won't exist
+        # at XenServer boot and therefore cannot be added as physical volumes to Local SR.
+        # Also, since the DM nodes are multipathed SANs it doesn't make sense to include them
+        # in the "Local" SR.
+        if isDeviceMapperNode(dev):
+            return False
+        return True
+
     diskEntries = list(filter(allowed_in_local_sr, diskEntries))
+    logger.info("select_guest_disks: filtered=%s", diskEntries)
+
+    if answers.get('swraid', False):
+        diskEntries = ["RAID"] + diskEntries
 
     if len(diskEntries) == 0 or constants.CC_PREPARATIONS:
         answers['guest-disks'] = []

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -603,6 +603,12 @@ def raid_array_ui(answers):
     tui.screen.popWindow()
     tui.screen.popHelpLine()
 
+    if buttons.buttonPressed(rc) == 'back':
+        answers['swraid'] = False
+        answers['physical-disks'] = []
+        logger.info("raid_array_ui: cancelled selection")
+        return REPEAT_STEP
+
     answers['swraid'] = True
     answers['physical-disks'] = cbt.getSelection()
     answers['primary-disk'] = ""

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -661,6 +661,11 @@ def select_primary_disk(answers):
     button = None
     diskEntries = sorted_disk_list()
 
+    # swraid is selected from the raid dialog, if we ever get back
+    # here we must not keep any previous choice, because user canceled
+    # that choice by selecting "Back"
+    answers['swraid'] = False
+
     entries = []
     min_primary_disk_size = constants.min_primary_disk_size
 

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -659,8 +659,7 @@ Are you sure you want to continue?"""
 # select drive to use as the Dom0 disk:
 def select_primary_disk(answers):
     button = None
-    diskEntries = ["RAID"] if answers.get('swraid', False) else []
-    diskEntries += sorted_disk_list()
+    diskEntries = sorted_disk_list()
 
     entries = []
     min_primary_disk_size = constants.min_primary_disk_size

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -566,7 +566,7 @@ def setup_runtime_networking(answers):
     return tui.network.requireNetworking(answers, defaults)
 
 def raid_array_ui(answers):
-    disk_entries = [e for e in sorted_disk_list() if not diskutil.is_raid(e)]
+    disk_entries = sorted_disk_list()
     raid_disks = [de for de in disk_entries if diskutil.is_raid(de)]
     raid_slaves = [slave for master in raid_disks for slave in diskutil.getDeviceSlaves(master)]
     entries = []


### PR DESCRIPTION
Version 10.10.38.xcpng.1 brings a raid support rewritten on top of upstream support.  Upstream support is limited to 2 disks, but the TUI allows to select an arbitrary number of disks (and the previous XCP-ng installers honored this).  Upstream code did not play well at all with anything 3 or more disks, only adding the first one to the RAID, and then trying to assemble the raid using all of the unprepared disks.

Additionally, the upstream way of creating the raid with only one disk, and adding the second one if there is one, creates a degraded RAID which rebuilds itself by copying useless data from one disk to another, so we fix that first.