### PR TITLE
linstor: find the expected RPMs version even if it's not the most recent in the repo

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -955,7 +955,7 @@ def listPackagesFromRepos(repos, rpm_pattern, query_format='%{nevr}'):
 
         rv, out = util.runCmd2(['repoquery', '-c', yum_conf_path,
                                 '--qf', query_format,
-                                rpm_pattern], with_stdout=True)
+                                '--show-duplicates', rpm_pattern], with_stdout=True)
     finally:
         for repo in repos:
             repo._accessor.finish()


### PR DESCRIPTION
Original code would get `repoquery` to list only the most recent version available for a RPM, and thus miss the older version included for upgrading from a previous XCP-ng release.