### PR TITLE
Fix linstor ugrade to pull specific version of `xcp-ng-linstor`

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -169,7 +169,7 @@ def getPrepSequence(ans, interactive):
 
 def getMainRepoSequence(ans, repos):
     seq = []
-    seq.append(Task(repository.installFromRepos, lambda a: [repos] + [a.get('mounts'), a.get('kernel-alt'), a.get('linstor-version')], [],
+    seq.append(Task(repository.installFromRepos, lambda a: [repos] + [a.get('mounts'), a.get('kernel-alt'), a.get('linstor-version'), a.get('xcp_ng_linstor')], [],
                 progress_scale=100,
                 pass_progress_callback=True,
                 progress_text="Installing %s..." % (", ".join([repo.name() for repo in repos]))))
@@ -458,6 +458,17 @@ def performInstallation(answers, ui_package, interactive):
                                "Please make sure your pool is uptodate and use the "
                                "latest dedicated ISO." %
                                (answers['linstor-version'], ', '.join(available_linstor_versions)))
+
+        dependents_on_requested_linstor = repository.runRepoquery(
+            main_repositories,
+            ["--whatrequires", "linstor-satellite-%s.noarch" % (answers['linstor-version'],)])
+        # --what-requires lists all versions, and the most recent is last
+        xcp_ng_linstors = [package for package in dependents_on_requested_linstor
+                           if package.startswith("xcp-ng-linstor-")]
+        if not xcp_ng_linstors:
+            raise RuntimeError("Failed to identify a suitable xcp-ng-linstor version")
+        answers['xcp_ng_linstor'] = xcp_ng_linstors[-1]
+        # FIXME: do we want to make sure that's installable here?
 
     # perform installation:
     prep_seq = getPrepSequence(answers, interactive)

--- a/product.py
+++ b/product.py
@@ -41,7 +41,7 @@ def is_rootfs_uefi(mount_point):
     return False
 
 def getLinstorVersion(rootfs_mount):
-    """ Returns the package version of the LINSTOR packages if any """
+    """ Returns the package version of the installed LINSTOR packages if any """
     command = ['rpm', '--root', rootfs_mount, '-q', '--qf', '%{evr}', 'linstor-satellite']
     rc, out = util.runCmd2(command, with_stdout=True)
     if rc != 0:

--- a/repository.py
+++ b/repository.py
@@ -903,7 +903,7 @@ baseurl=%s
             if repo_config is not None:
                 yum_conf.write(repo_config)
 
-def installFromRepos(progress_callback, repos, mounts, kernel_alt, linstor_version):
+def installFromRepos(progress_callback, repos, mounts, kernel_alt, linstor_version, xcp_ng_linstor):
     """Install from a stacked set of repositories"""
 
     logger.log("installFromRepos, kernel_alt=%s" % (kernel_alt,))
@@ -925,7 +925,8 @@ def installFromRepos(progress_callback, repos, mounts, kernel_alt, linstor_versi
         if kernel_alt:
             targets.append('kernel-alt')
         if linstor_version:
-            targets.extend(['xcp-ng-release-linstor', 'xcp-ng-linstor',
+            targets.extend(['xcp-ng-release-linstor',
+                            xcp_ng_linstor,
                             'linstor-satellite-%s' % linstor_version,
                             'linstor-controller-%s' % linstor_version,
                             ])
@@ -944,7 +945,7 @@ def hideNullEpoch(package):
         return package
     return "".join(m.groups())
 
-def listPackagesFromRepos(repos, rpm_pattern, query_format='%{nevr}'):
+def runRepoquery(repos, args):
     cachedir = "var/cache/yum/installer"
     yum_conf_path = '/root/yum-repoquery.conf'
 
@@ -954,11 +955,13 @@ def listPackagesFromRepos(repos, rpm_pattern, query_format='%{nevr}'):
     try:
         createMainYumConfig(yum_conf_path, repos, cachedir, repogpgcheck_override=0)
 
-        rv, out = util.runCmd2(['repoquery', '-c', yum_conf_path,
-                                '--qf', query_format,
-                                '--show-duplicates', rpm_pattern], with_stdout=True)
+        rv, out = util.runCmd2(['repoquery', '-c', yum_conf_path] + args, with_stdout=True)
     finally:
         for repo in repos:
             repo._accessor.finish()
 
-    return [hideNullEpoch(package) for package in out.split()]
+    return out.split()
+
+def listPackagesFromRepos(repos, rpm_pattern, query_format='%{nevr}'):
+    return [hideNullEpoch(package) for package in
+            runRepoquery(repos, ['--qf', query_format, '--show-duplicates', rpm_pattern])]


### PR DESCRIPTION
Each `xcp-ng-linstor` pulls a minimal version of `linstor-*` packages, and when `yum` sees it pull a more recent version than what we explicitly request on commandline, it just disregards what we requested and goes in installing the more recent one, instead of erroring out as it should. Sigh.

We have to identify ourselves which versions of `xcp-ng-linstor` are actually compatible with what we want to install, and explicitly request one to avoid this situation.